### PR TITLE
Enable c++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 CC=$(HOME)/cheri/output/sdk/bin/riscv64-unknown-freebsd13-clang
+CXX=$(HOME)/cheri/output/sdk/bin/riscv64-unknown-freebsd13-clang++
 CFLAGS=-march=rv64imafdcxcheri -mabi=l64pc128d --sysroot=$(HOME)/cheri/output/rootfs-riscv64-purecap -mno-relax -g -O0
 SSHPORT=10021
 export 
 
 cfiles := $(wildcard *.c)
-examples := $(patsubst %.c,bin/%,$(cfiles))
+cppfiles := $(wildcard *.cpp)
+examples := $(patsubst %.c,bin/%,$(cfiles)) $(patsubst %.cpp,bin/%,$(cfiles))
 
 .PHONY: all run clean
 
@@ -12,6 +14,10 @@ all: $(examples)
 
 bin/%: %.c
 	$(CC) $(CFLAGS) $< -o $@
+	scp -P $(SSHPORT) $< root@127.0.0.1:/root
+
+bin/%: %.cpp
+	$(CXX) $(CFLAGS) $< -o $@
 	scp -P $(SSHPORT) $< root@127.0.0.1:/root
 
 run-%: bin/%

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC=$(HOME)/cheri/output/sdk/bin/riscv64-unknown-freebsd13-clang
-CFLAGS=-march=rv64imafdcxcheri -mabi=l64pc128d --sysroot=$(HOME)/cheri/output/rootfs-riscv64-hybrid -mno-relax -g -O0
-SSHPORT=10017
+CFLAGS=-march=rv64imafdcxcheri -mabi=l64pc128d --sysroot=$(HOME)/cheri/output/rootfs-riscv64-purecap -mno-relax -g -O0
+SSHPORT=10021
 export 
 
 cfiles := $(wildcard *.c)
@@ -12,9 +12,10 @@ all: $(examples)
 
 bin/%: %.c
 	$(CC) $(CFLAGS) $< -o $@
+	scp -P $(SSHPORT) $< root@127.0.0.1:/root
 
 run-%: bin/%
-	scp -P $(SSHPORT) bin/$(<F) $(<F).c root@127.0.0.1:/root
+	scp -P $(SSHPORT) bin/$(<F) root@127.0.0.1:/root
 	ssh -p $(SSHPORT) root@127.0.0.1 -t '/root/$(<F)'
 
 clean: 

--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,13 @@ all: $(examples)
 
 bin/%: %.c
 	$(CC) $(CFLAGS) $< -o $@
-	scp -P $(SSHPORT) $< root@127.0.0.1:/root
 
 bin/%: %.cpp
 	$(CXX) $(CFLAGS) $< -o $@
-	scp -P $(SSHPORT) $< root@127.0.0.1:/root
 
-run-%: bin/%
-	scp -P $(SSHPORT) bin/$(<F) root@127.0.0.1:/root
+.SECONDEXPANSION:
+run-%: bin/% $$(wildcard %.c) $$(wildcard %.cpp)
+	scp -P $(SSHPORT) $(word 2,$^) bin/$(<F) root@127.0.0.1:/root
 	ssh -p $(SSHPORT) root@127.0.0.1 -t '/root/$(<F)'
 
 clean: 

--- a/hello-cxx.cpp
+++ b/hello-cxx.cpp
@@ -1,0 +1,13 @@
+#include <iostream>
+#include <vector>
+#include <cheri.h>
+#include "include/common.h"
+
+int main() {
+	std::vector<int> list = { 1, 2, 3, 4 };
+	for(unsigned int i = 0; i <= 16; i++) {
+		inspect_pointer(&list[i]);
+		std::cout << "Value: " << list[i] << std::endl;
+	}
+	
+}

--- a/hello.c
+++ b/hello.c
@@ -11,7 +11,7 @@ int main()
 	int32_t *typed_array = &array;
 	int32_t *aptr = &array;
 
-	uint64_t length = cheri_length_get(typed_array);
+	uint64_t length = cheri_getlength(typed_array);
 	for (uint32_t counter = 0; counter <= (length / sizeof(int32_t)) + 16; counter++)
 	{
 		inspect_pointer(typed_array + counter);

--- a/hello.c
+++ b/hello.c
@@ -1,6 +1,4 @@
 #include "include/common.h"
-//#include <cheri/cheric.h>
-#include <cheriintrin.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/include/common.h
+++ b/include/common.h
@@ -1,23 +1,23 @@
 #include<stdio.h>
 #include<stdint.h>
-#include <cheriintrin.h>
+#include<cheri/cheri.h>
+#include<cheri/cheric.h>
+
 #include<stdbool.h>
 
 void inspect_pointer(void *ptr)
 {
-	
-	uint64_t length = cheri_length_get(ptr);
-	uint64_t address = cheri_address_get(ptr);
-	uint64_t base = cheri_base_get(ptr);
-	uint64_t flags = cheri_flags_get(ptr);
-	uint64_t perms = cheri_perms_get(ptr);
-	uint64_t type = cheri_type_get(ptr);	
-	bool tag = cheri_tag_get(ptr);
-	bool valid = cheri_is_valid(ptr);
+	uint64_t length = cheri_getlength(ptr);
+	uint64_t address = cheri_getaddress(ptr);
+	uint64_t base = cheri_getbase(ptr);
+	uint64_t flags = cheri_getflags(ptr);
+	uint64_t perms = cheri_getperm(ptr);
+	uint64_t type = cheri_gettype(ptr);	
+	bool tag = cheri_gettag(ptr);
 
-	uint64_t offset = __builtin_cheri_offset_get(ptr);
-	printf("Address: %04lx, Base: %04lx, End: %04lx Flags: %04lx, Length: %04lx, Offset: %04lx, Perms: %04lx, Type: %04lx, Tag: %d, Valid: %d\n",
-			address, base, base + length, flags, length, offset, perms, type, tag, valid);
+	uint64_t offset = cheri_getoffset(ptr);
+	printf("Address: %04lx, Base: %04lx, End: %04lx Flags: %04lx, Length: %04lx, Offset: %04lx, Perms: %04lx, Type: %04lx, Tag: %d\n",
+			address, base, base + length, flags, length, offset, perms, type, tag);
 }
 
 
@@ -32,7 +32,7 @@ void error(char* string) {
 // We don't want to inline it because __builtin_frame_address will change it's meaning.
 // __builtin_frame_address gives you the stack bottom of the current function.
 // This will be the stack top of the calling function.
-__attribute__((noinline)) void* cheri_csp_get()
+__attribute__((noinline)) void* cheri_getcsp()
 {
 	return __builtin_frame_address(0);
 }

--- a/mmap.c
+++ b/mmap.c
@@ -26,7 +26,7 @@ uint32_t *generate_purecap(uint32_t *code)
 {
 	uint32_t idx = 0;
 
-	if (cheri_length_get(code) <= (9 * sizeof(uint32_t)))
+	if (cheri_getlength(code) <= (9 * sizeof(uint32_t)))
 	{
 		error("Insufficient size");
 		exit(-1);
@@ -55,7 +55,7 @@ uint32_t *generate_purecap(uint32_t *code)
 	 * When in capability mode the capability of the corresponding capability register is used.
 	 * For example, if you try to access a0 that would use the capability inside of ca0
 	 */
-	return cheri_flags_set(code, 0x0001);
+	return cheri_setflags(code, 0x0001);
 }
 
 /*
@@ -69,7 +69,7 @@ uint32_t *generate_hybrid(uint32_t *code)
 {
 	uint32_t idx = 0;
 
-	if (cheri_length_get(code) <= (10 * sizeof(uint32_t)))
+	if (cheri_getlength(code) <= (10 * sizeof(uint32_t)))
 	{
 		error("Insufficient size");
 		exit(-1);
@@ -92,7 +92,7 @@ uint32_t *generate_micro(uint32_t *code)
 {
 	uint32_t idx = 0;
 
-	if (cheri_length_get(code) <= (2 * sizeof(uint32_t)))
+	if (cheri_getlength(code) <= (2 * sizeof(uint32_t)))
 	{
 		error("Insufficient size");
 		exit(-1);

--- a/mmap.c
+++ b/mmap.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <sys/cdefs.h>
 #include <sys/mman.h>
+#include <cheri/cheric.h>
 
 uint32_t *get_executable_block()
 {
@@ -107,7 +108,7 @@ int main()
 	code = get_executable_block();
 	code = generate_purecap(code);
 
-	inspect_pointer(cheri_pcc_get());
+	inspect_pointer(cheri_getpcc());
 	inspect_pointer(code);
 
 	int (*code_function)() = (int (*)())code;

--- a/set_bounds.c
+++ b/set_bounds.c
@@ -1,6 +1,5 @@
 #include "include/common.h"
 #include <cheri/cheric.h>
-#include <cheriintrin.h>
 #include <stdint.h>
 #include <stdio.h>
 

--- a/set_bounds.c
+++ b/set_bounds.c
@@ -20,7 +20,7 @@ int main()
 
 	int32_t *custom_boundes_array = cheri_setbounds(array, bounds);
 
-	uint64_t length = cheri_length_get(custom_boundes_array);
+	uint64_t length = cheri_getlength(custom_boundes_array);
 	for (uint32_t counter = 0; counter < length / sizeof(int32_t); counter++)
 	{
 		inspect_pointer(custom_boundes_array + counter);

--- a/setjmp.c
+++ b/setjmp.c
@@ -10,7 +10,7 @@ int main()
 	jmp_buf buffer;
 	int res = setjmp(buffer);
 
-	uint32_t length = cheri_length_get(buffer);
+	uint32_t length = cheri_getlength(buffer);
 
 	// buffer[0] == _JB_MAGIC_SETJMP == 0xbe87fd8a2910af01
 	// buffer[1] == $csp
@@ -21,12 +21,10 @@ int main()
 	{
 		if (cheri_gettag(((void **)buffer)[idx]))
 		{
-			void *csp = cheri_csp_get();
-			uint64_t base = cheri_base_get(csp);
-			uint64_t length = cheri_length_get(csp);
+			void *csp = cheri_getcsp();
 			uint64_t address = cheri_getaddress(((void **)buffer)[idx]);
 
-			if (address >= base && address <= (base + length))
+			if (cheri_is_address_inbounds(csp, address))
 			{
 				printf("[STACK POINTER] ");
 			}

--- a/setjmp.c
+++ b/setjmp.c
@@ -3,6 +3,7 @@
 #include <setjmp.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <cheri/cheric.h>
 
 int main()
 {
@@ -18,12 +19,12 @@ int main()
 	// buffer[14..31] = ???
 	for (uint32_t idx; idx < (length / 16); idx++)
 	{
-		if (cheri_is_valid(((void **)buffer)[idx]))
+		if (cheri_gettag(((void **)buffer)[idx]))
 		{
 			void *csp = cheri_csp_get();
 			uint64_t base = cheri_base_get(csp);
 			uint64_t length = cheri_length_get(csp);
-			uint64_t address = cheri_address_get(((void **)buffer)[idx]);
+			uint64_t address = cheri_getaddress(((void **)buffer)[idx]);
 
 			if (address >= base && address <= (base + length))
 			{

--- a/stackscan.c
+++ b/stackscan.c
@@ -15,11 +15,11 @@ void inspect_stack(void *stack)
 
 bool is_stack_pointer(void *ptr)
 {
-	if (cheri_is_valid(ptr))
+	if (cheri_gettag(ptr))
 	{
 		uint64_t base = cheri_base_get(stack_top);
 		uint64_t length = cheri_length_get(stack_top);
-		uint64_t address = cheri_address_get(ptr);
+		uint64_t address = cheri_getaddress(ptr);
 
 		if (address >= base && address <= (base + length))
 		{
@@ -31,7 +31,7 @@ bool is_stack_pointer(void *ptr)
 
 bool is_pointer(void *ptr)
 {
-	if (cheri_is_valid(ptr))
+	if (cheri_gettag(ptr))
 	{
 		return true;
 	}


### PR DESCRIPTION
Allow for c++ code to be used in the examples, and switch to purecap mode for the sysroot.
Also, switch to the intrinsics in all the examples to the ones from the sysroot as their header file work with c++.
The reason for the switch is that on the CHERI slack it was mentioned that the purecap mode should be the default.