### PR TITLE
Add example showing the usage of .so files.

### DIFF
--- a/shared_objects/.gitignore
+++ b/shared_objects/.gitignore
@@ -1,0 +1,3 @@
+*.so
+.cache
+*.json

--- a/shared_objects/Makefile
+++ b/shared_objects/Makefile
@@ -1,0 +1,16 @@
+CC=$(HOME)/cheri/output/sdk/bin/riscv64-unknown-freebsd13-clang
+CFLAGS=-march=rv64imafdcxcheri -mabi=l64pc128d --sysroot=$(HOME)/cheri/output/rootfs-riscv64-hybrid -mno-relax -g
+SSHPORT=10021
+
+main: main.c
+	$(CC) $(CFLAGS) -L. -l1 -l2 -g $< -o main
+
+lib1.so: lib1.c
+	$(CC) $(CFLAGS) -g -fPIC -shared $< -o lib1.so
+
+lib2.so: lib2.c
+	$(CC) $(CFLAGS) -g -fPIC -shared $< -o lib2.so
+
+run:
+	scp -P $(SSHPORT) * root@127.0.0.1:/root/demo/
+	ssh -p $(SSHPORT) root@127.0.0.1 -t 'setenv LD_LIBRARY_PATH /root/demo; /root/demo/main'

--- a/shared_objects/include/lib1.h
+++ b/shared_objects/include/lib1.h
@@ -1,0 +1,8 @@
+#pragma once
+#include<stdio.h>
+#include<stdlib.h>
+#include<stdint.h>
+
+void increment();
+
+int get_count();

--- a/shared_objects/include/lib2.h
+++ b/shared_objects/include/lib2.h
@@ -1,0 +1,19 @@
+#pragma once
+#include<stdio.h>
+#include<stdlib.h>
+#include<stdint.h>
+
+struct Car_priv {
+	int maxSpeed;
+	void (*crash)();
+};
+
+struct Car {
+	int speed;
+	void (*honk)();
+	char name[];
+};
+
+void init();
+
+struct Car* new_car();

--- a/shared_objects/lib1.c
+++ b/shared_objects/lib1.c
@@ -1,0 +1,25 @@
+/**
+ * A basic example showing how CHERI sealed entries can be used to protect data. In this case the
+ * cont variable will be inaccessible from the things that link with this shared library.
+ */
+
+#include "include/lib1.h"
+
+static int32_t count = -5;
+
+void increment()
+{
+	count += 1;
+}
+
+int get_count()
+{
+	if (count > 0)
+	{
+		return count;
+	}
+	else
+	{
+		return 0;
+	}
+}

--- a/shared_objects/lib2.c
+++ b/shared_objects/lib2.c
@@ -1,0 +1,70 @@
+/**
+ * A more complicated example of sealed entries displaying how they can be used to protect private
+ * data that will and can be given to the user of the library as a pointer. In this case Car_priv is
+ * the private fields and methods of the object that is given to the user, and it is protected by
+ * exploiting the properties of the sealed entries (The fact that the capability can only be jumped
+ * to not modified in any way).
+ */
+
+#include <cheri/cheri.h>
+#include <cheri/cheric.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <stddef.h>
+
+#include "../include/instructions.h"
+#include "../include/regs.h"
+#include "include/lib2.h"
+
+static struct Car *arena;
+static uint32_t size;
+
+void init() {}
+
+void crash()
+{
+	printf("CRASH!\n");
+}
+
+void honk(struct Car_priv *priv, struct Car *car)
+{
+	printf("%p %p\n", priv, car);
+	printf("HONK!\n");
+	if (car->speed > priv->maxSpeed)
+	{
+		priv->crash();
+	}
+}
+
+struct Car *new_car()
+{
+	uint32_t *mem =
+		mmap(NULL, 4096, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_ANON | MAP_PRIVATE, -1, 0);
+
+	void **ptrs = mem;
+	
+	const uint32_t vtable_start_index = 2;
+	ptrs[vtable_start_index + 0] = honk;
+
+	const ptrdiff_t vtable_offset = ((char*)(ptrs + vtable_start_index) - (char*)ptrs);
+	const size_t vtable_size = 1 * 16;
+
+	uint32_t idx = 0;
+	mem[idx++] = auipcc(cs2, 0);
+	mem[idx++] = clc_128(cs3, cs2, vtable_offset);
+	mem[idx++] = cincoffsetimm(ca0, cs2, vtable_offset + vtable_size);
+	mem[idx++] = cincoffsetimm(ca1, cs2, vtable_offset + vtable_size + sizeof(struct Car_priv));
+	mem[idx++] = cjalr(cnull, cs3);
+
+	uint32_t functions_size = vtable_offset + vtable_size;
+	struct Car *public_car =
+		(struct Car *)(((char *)mem) + sizeof(struct Car_priv) + functions_size);
+	struct Car_priv *private_car = (struct Car_priv *)(((char *)mem) + functions_size);
+	
+	private_car->maxSpeed = 10;
+	private_car->crash = &crash;
+
+	public_car->honk = cheri_sealentry(cheri_setflags(mem, 1));
+
+	return public_car;
+}

--- a/shared_objects/main.c
+++ b/shared_objects/main.c
@@ -1,0 +1,32 @@
+/**
+ * Displays how lib1 and lib2 will look like from the point of view of the users of the libraries.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "include/lib1.h"
+#include "include/lib2.h"
+
+int main()
+{
+	struct Car *car = new_car();
+	car->speed = 1;
+	car->honk();
+
+	car->speed = 999;
+	car->honk();
+
+	increment();
+	increment();
+	increment();
+
+	printf("Count: %d\n", get_count());
+
+	increment();
+	increment();
+	increment();
+
+	printf("Count: %d\n", get_count());
+}


### PR DESCRIPTION
This example is needed to present the implications of using shared libraries. How they can be used as a proxy for deciding what is
public and what is private by means of what is being exported and how does it integrate with the changes made on the linker (rtld) as needed by CHERI. 
This is what lead to deciding to split the lua VM into multiple shared objects. But this example also contains the idea for creating compartments purely from the program counter capability (PCC) and using it to protect data that should be private for a function. 