### PR TITLE
cmake build file with riscv toolchain file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required (VERSION 3.15.0) 
+
+project(CHERI_EXAMPLES 
+	VERSION 0.1 
+	DESCRIPTION "Stub examples showing how to exploit capabilities"
+	LANGUAGES C)
+
+get_filename_component(COMP_NAME ${CMAKE_C_COMPILER} NAME_WE)
+
+add_executable(allocate allocate.c) 
+add_executable(check_length check_length.c) 
+add_executable(check_mask check_mask.c) 
+add_executable(function function.c) 
+add_executable(hello hello.c) 
+add_executable(mmap mmap.c) 
+if( ${COMP_NAME} MATCHES "^mips*" )
+  add_executable(seal seal.c) 
+endif() 
+add_executable(sentry sentry.c) 
+add_executable(set_bounds set_bounds.c) 
+add_executable(setjmp setjmp.c) 
+add_executable(stackscan stackscan.c) 
+add_executable(xor_pointers xor_pointers.c) 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # cheri-examples
 cheri-riscv sample c programs
+
+------
+## Build instructions with CMake
+Build all the example code with CMake using default settings :
+1. Create a separate build directory (\<build-dir\>) outside the source directory (\<source-dir\>).
+2. Generate the build files using either **Unix Makefiles** (*default*) or **Ninja** (specfied
+   with **-G**). Currently only the *RISC-V* cheri-purecap toolchain file has been created.
+   1. If executing from inside the build directory :
+
+   `cmake -DCMAKE_TOOLCHAIN_FILE=riscv64-purecap.cmake <relative-path-to-source-dir>`
+
+   2. If executing from outside the build directory :
+
+   `cmake -B <build-dir> -S <source-dir> -DCMAKE_TOOLCHAIN_FILE=riscv64-purecap.cmake`
+
+3. Build all the examples
+   1. If executing from inside the build directory,  `make all` *OR* `ninja all`
+   2. If executing from outside the build directory, `cmake --build <build-dir>`
+
+#### CMake options:
+* **-DCMAKE_TOOLCHAIN_FILE**: Use `-DCMAKE_TOOLCHAIN_FILE=<toolchain-file>` to select
+  architecture to compile binary for. Only *riscv64-purecap.cmake* is currently supported.
+* **-DSDK**: Use `-DSDK=<source-to-sdk>` to point to the *CHERI* SDK directory.
+  (Default path: ${HOME}/cheri/output/sdk)
+* **-G**: Choose preferred build system
+  - Use `-G "Unix Makefiles"` to build using *makefiles* (*default*).
+  - Use `-G Ninja` to build using *ninja*.

--- a/riscv64-purecap.cmake
+++ b/riscv64-purecap.cmake
@@ -1,0 +1,23 @@
+set(CMAKE_SYSTEM_NAME Linux)
+
+# Default SDK path
+set(SDK "$ENV{HOME}/cheri/output/sdk" CACHE PATH "path to cheri SDK")
+
+# Set toolchain compilers
+set(CMAKE_C_COMPILER ${SDK}/bin/riscv64-unknown-freebsd13-cc)
+set(CMAKE_CXX_COMPILER ${SDK}/bin/riscv64-unknown-freebsd13-c++)
+
+# Don't run the linker on compiler check
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+# Define sysroot path for CHERI-build`
+set(CMAKE_SYSROOT ${SDK}/sysroot-riscv64-purecap)
+
+# Use only cross compiler tools for compilation and linking
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# Set correct machine and abi flags
+add_compile_options(-march=rv64imafdcxcheri -mabi=l64pc128d -mno-relax)
+add_link_options(-march=rv64imafdcxcheri -mabi=l64pc128d -mno-relax)


### PR DESCRIPTION
* Use CMake to build all the cheri examples
* Select architecture to compile for from command line 
* Set tool chain and SDK paths based on architecture

*Note* : currently only the risc-v implementation is done