### PR TITLE
Integrate the new compilation process, and add the cmake build to the .buildbot.sh build script.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -9,3 +9,12 @@ for example in *.c; do
     fi
     make bin/"${example%%.*}"
 done
+
+mkdir build 
+cd build
+    
+cmake -DCMAKE_TOOLCHAIN_FILE=riscv64-purecap.cmake ..
+make
+
+cd ..
+rm -rfv build

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-CC=$(HOME)/cheri/output/sdk/bin/riscv64-unknown-freebsd13-clang
-CXX=$(HOME)/cheri/output/sdk/bin/riscv64-unknown-freebsd13-clang++
-CFLAGS=-march=rv64imafdcxcheri -mabi=l64pc128d --sysroot=$(HOME)/cheri/output/rootfs-riscv64-purecap -mno-relax -g -O0
+CC=$(HOME)/cheri/output/sdk/bin/clang
+CXX=$(HOME)/cheri/output/sdk/bin/clang++
+CFLAGS=-fuse-ld=lld --config cheribsd-riscv64-purecap.cfg
 SSHPORT=10021
 export 
 

--- a/riscv64-purecap.cmake
+++ b/riscv64-purecap.cmake
@@ -4,14 +4,14 @@ set(CMAKE_SYSTEM_NAME Linux)
 set(SDK "$ENV{HOME}/cheri/output/sdk" CACHE PATH "path to cheri SDK")
 
 # Set toolchain compilers
-set(CMAKE_C_COMPILER ${SDK}/bin/riscv64-unknown-freebsd13-cc)
-set(CMAKE_CXX_COMPILER ${SDK}/bin/riscv64-unknown-freebsd13-c++)
+set(CMAKE_C_COMPILER ${SDK}/bin/clang)
+set(CMAKE_CXX_COMPILER ${SDK}/bin/clang++)
 
 # Don't run the linker on compiler check
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
 # Define sysroot path for CHERI-build`
-set(CMAKE_SYSROOT ${SDK}/sysroot-riscv64-purecap)
+# set(CMAKE_SYSROOT ${SDK}/sysroot-riscv64-purecap)
 
 # Use only cross compiler tools for compilation and linking
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
@@ -19,5 +19,5 @@ set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 
 # Set correct machine and abi flags
-add_compile_options(-march=rv64imafdcxcheri -mabi=l64pc128d -mno-relax)
-add_link_options(-march=rv64imafdcxcheri -mabi=l64pc128d -mno-relax)
+add_compile_options(--config cheribsd-riscv64-purecap.cfg)
+add_link_options(-fuse-ld=lld --config cheribsd-riscv64-purecap.cfg)

--- a/shared_objects/Makefile
+++ b/shared_objects/Makefile
@@ -1,5 +1,5 @@
-CC=$(HOME)/cheri/output/sdk/bin/riscv64-unknown-freebsd13-clang
-CFLAGS=-march=rv64imafdcxcheri -mabi=l64pc128d --sysroot=$(HOME)/cheri/output/rootfs-riscv64-hybrid -mno-relax -g
+CC=$(HOME)/cheri/output/sdk/bin/clang
+CFLAGS=-g -fuse-ld=lld --config cheribsd-riscv64-purecap.cfg
 SSHPORT=10007
 
 main: main.c


### PR DESCRIPTION
Switched from using `riscv64-unknown-freebsd13-clang` to
`clang --config cheribsd-riscv64-purcap.cfg`. Now the only
linker that can be used is llvm's lld by doing `-fuse-ld=lld`.
Also included the new cmake build system in the build script.