### PR TITLE
Rename the builder used for status for bors.

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,4 @@
-status = ["buildbot/cheri-build-script"]
+status = ["buildbot/capablevms-test-script"]
 
 timeout_sec = 600 # 10 minutes
 


### PR DESCRIPTION
I have renamed the name of the builder on the buildbot server as the names: cheri-build-script and cheribuild-script are very confusing.
You can see it here: http://bencher14.soft-dev.org:8010/