### PR TITLE
Add Morello support to Makefile

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -9,7 +9,7 @@ for example in *.c; do
     if [ "${example}" == "seal.c" ]; then
         continue
     fi
-    make bin/"${example%%.*}"
+    make -f Makefile.riscv64 bin/"${example%%.*}"
 done
 
 # arg-1 : Source directory

--- a/Makefile.morello
+++ b/Makefile.morello
@@ -1,0 +1,31 @@
+CC=$(HOME)/cheri/output/morello-sdk/bin/clang
+CFORMAT=$(HOME)/cheri/output/morello-sdk/bin/clang-format
+CXX=$(HOME)/cheri/output/morello-sdk/bin/clang++
+CFLAGS=-fuse-ld=lld --config cheribsd-morello-purecap.cfg
+SSHPORT=10085
+export
+
+cfiles := $(wildcard *.c)
+cppfiles := $(wildcard *.cpp)
+examples := $(patsubst %.c,bin/%,$(cfiles)) $(patsubst %.cpp,bin/%,$(cfiles))
+
+.PHONY: all run clean
+
+all: $(examples)
+	
+bin/%: %.c
+	$(CC) $(CFLAGS) $< -o $@
+
+bin/%: %.cpp
+	$(CXX) $(CFLAGS) $< -o $@
+
+.SECONDEXPANSION:
+run-%: bin/% $$(wildcard %.c) $$(wildcard %.cpp)
+	scp -P $(SSHPORT) $(word 2,$^) bin/$(<F) root@127.0.0.1:/root
+	ssh -p $(SSHPORT) root@127.0.0.1 -t '/root/$(<F)'
+
+clang-format:
+	$(CFORMAT) $(cfiles)
+
+clean: 
+	rm -rv bin/*

--- a/Makefile.riscv64
+++ b/Makefile.riscv64
@@ -3,7 +3,7 @@ CFORMAT=$(HOME)/cheri/output/sdk/bin/clang-format
 CXX=$(HOME)/cheri/output/sdk/bin/clang++
 CFLAGS=-fuse-ld=lld --config cheribsd-riscv64-purecap.cfg
 SSHPORT=10021
-export 
+export
 
 cfiles := $(wildcard *.c)
 cppfiles := $(wildcard *.cpp)


### PR DESCRIPTION
Add Morello support to Makefile

- default architecture is Morello
- ENV files to switch to riscv64