### PR TITLE
Employee example to show permissions in action

### DIFF
--- a/employee/Makefile
+++ b/employee/Makefile
@@ -1,0 +1,27 @@
+CC=$(HOME)/cheri/output/sdk/bin/clang
+CFORMAT=$(HOME)/cheri/output/sdk/bin/clang-format
+CFLAGS=-fuse-ld=lld --config cheribsd-riscv64-purecap.cfg
+SSHPORT=10021
+export
+
+read_only := read_only.c employee.c
+full_privileges := full_privileges.c employee.c
+
+all: bin/full_privileges bin/read_only
+
+bin/read_only: $(read_only)
+	$(CC) $(CFLAGS) $^ -o $@
+
+bin/full_privileges: $(full_privileges)
+	$(CC) $(CFLAGS) $^ -o $@
+
+run:
+	scp -P $(SSHPORT) bin/* root@127.0.0.1:/root
+	ssh -p $(SSHPORT) root@127.0.0.1 -t '/root/full_privileges'
+	ssh -p $(SSHPORT) root@127.0.0.1 -t '/root/read_only'
+
+clang-format:
+	$(CFORMAT) -i $(cfiles)
+
+clean: 
+	rm -R bin/*

--- a/employee/employee.c
+++ b/employee/employee.c
@@ -1,0 +1,23 @@
+/*
+ * Auxiliary functions to display employee's details and
+ * change the salary.
+ */
+
+#include "include/employee.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void change_salary(struct employee *e, double salary)
+{
+	e->salary = salary;
+}
+
+void print_details(struct employee *e)
+{
+	printf("Employee Id: %d \n", e->id);
+	printf("Employee Name: %s \n", e->name);
+	printf("Employee Surname: %s\n", e->surname);
+	printf("Employee Salary: %lf\n", e->salary);
+	fflush(stdout);
+}

--- a/employee/full_privileges.c
+++ b/employee/full_privileges.c
@@ -1,0 +1,20 @@
+/* A normal program without any capabilities set.
+ * Print the details of a generic employee and
+ * and then allows the user to change the salary.
+ */
+
+#include "include/employee.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main()
+{
+	struct employee employee = {0, "Good", "Employee", 55000};
+	double salary = 0.0;
+	print_details(&employee);
+	printf("\nInsert the new salary for this employee: \n");
+	scanf("%lf", &salary);
+	change_salary(&employee, salary);
+	print_details(&employee);
+}

--- a/employee/include/employee.h
+++ b/employee/include/employee.h
@@ -1,0 +1,16 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+struct employee
+{
+	int id;
+	char *name;
+	char *surname;
+	double salary;
+};
+
+void change_salary(struct employee *e, double salary);
+void print_details(struct employee *e);
+
+struct employee *set_read_only(struct employee *e);

--- a/employee/read_only.c
+++ b/employee/read_only.c
@@ -1,0 +1,42 @@
+/* This program is very similar to "full_privileges.c"
+ * but here we set the permissions of the capability
+ * to LOAD, i.e. read-only. So the user is not allowed to
+ * change the salary.
+ */
+
+#include "../include/common.h"
+#include "include/employee.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main()
+{
+	struct employee employee = {0, "Good", "Employee", 55000};
+	double salary = 0.0;
+	// set the permissions to read-only
+	struct employee *ro_employee = set_read_only(&employee);
+	inspect_pointer(ro_employee);
+	print_details(ro_employee);
+	printf("The struct is read-only so trying to change the salary will make the program crash...");
+	printf("\nInsert the new salary for this employee: \n");
+	fflush(stdout);
+	scanf("%lf", &salary);
+
+	change_salary(ro_employee, salary);
+	print_details(ro_employee);
+}
+
+/*
+ * Traverse the struct to set the permissions.
+ */
+struct employee *set_read_only(struct employee *e)
+{
+	char *ro_name = (char *)cheri_perms_and(e->name, CHERI_PERM_LOAD);
+	char *ro_surname = (char *)cheri_perms_and(e->surname, CHERI_PERM_LOAD);
+	struct employee *ro_employee =
+		(struct employee *)cheri_perms_and(e, CHERI_PERM_LOAD || CHERI_PERM_LOAD_CAP);
+	ro_employee->name = ro_name;
+	ro_employee->surname = ro_surname;
+	return ro_employee;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # Test runner to test the following examples:
-# bounds.c, set_bounds.c, general_bounds.c, xor_pointers.c.
+# bounds.c, set_bounds.c, general_bounds.c, xor_pointers.c,
+# read_only.c (from the employee example)
 #
 # *** NOTE ***
 # The following examples do not need to be
@@ -13,8 +14,16 @@ set -e
 : "${BUILD_DIR:="../bin"}"
 : "${SSHPORT:=10021}"
 # Examples that must trigger an "In-address space security exception"
-EXAMPLES="bounds set_bounds general_bounds xor_pointers"
+EXAMPLES="bounds set_bounds general_bounds xor_pointers read_only"
+EMPLOYEE_DIR="./employee/bin"
 ARCH=$(ssh -o "StrictHostKeyChecking no" -p $SSHPORT -t root@127.0.0.1 uname -m)
+
+if  [ ! $(find $EMPLOYEE_DIR -prune -empty 2>/dev/null) ]; then
+    cp $EMPLOYEE_DIR/read_only $BUILD_DIR/read_only
+else
+    echo "WARNING: you have not built the employee example yet!"
+    echo "SKIPPING employee/read_only..."
+fi
 
 for example in ${EXAMPLES}; do
     if  [ ! $(find $BUILD_DIR -prune -empty 2>/dev/null) ]; then
@@ -25,6 +34,9 @@ for example in ${EXAMPLES}; do
         scp -o "StrictHostKeyChecking no" -P $SSHPORT "$BUILD_DIR/$example" root@127.0.0.1:/root
         exit_status=0
         RESULT={{$(ssh -o "StrictHostKeyChecking no" -p $SSHPORT -t root@127.0.0.1 "/root/$example 68")} && exit_status=1} || true
+        if [ "$example" = "read_only" ]; then
+            example=employee/$example
+        fi
         echo -n ""$example"... "
         if [ $exit_status != 0 ]; then
             echo "FAILED! See below for more details."


### PR DESCRIPTION
Simple example to show how permissions work. A struct is made read-only by setting CHERI_PERM_LOAD.