### PR TITLE
We don't need CMake 3.15.0.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.15.0) 
+cmake_minimum_required (VERSION 3.13.0) 
 
 project(CHERI_EXAMPLES 
 	VERSION 0.1 


### PR DESCRIPTION
Since Debian 10 only has 3.13.0 this requirement is a bit annoying!