### PR TITLE
Reading from the read-only struct should not cause an In-address Security Exception

### DIFF
--- a/employee/Makefile
+++ b/employee/Makefile
@@ -4,6 +4,7 @@ CFLAGS=-fuse-ld=lld --config cheribsd-riscv64-purecap.cfg
 SSHPORT=10021
 export
 
+employee := full_privileges.c read_only.c employee.c include/employee.h
 read_only := read_only.c employee.c
 full_privileges := full_privileges.c employee.c
 
@@ -23,7 +24,7 @@ run:
 	ssh -p $(SSHPORT) root@127.0.0.1 -t '/root/read_only'
 
 clang-format:
-	$(CFORMAT) -i $(cfiles)
+	$(CFORMAT) -i $(employee)
 
 clean: 
 	rm -R bin/*

--- a/employee/employee.c
+++ b/employee/employee.c
@@ -15,9 +15,9 @@ void change_salary(struct employee *e, double salary)
 
 void print_details(struct employee *e)
 {
-	printf("Employee Id: %d \n", e->id);
+	printf("Employee Id: %d\n", e->id);
 	printf("Employee Name: %s \n", e->name);
 	printf("Employee Surname: %s\n", e->surname);
-	printf("Employee Salary: %lf\n", e->salary);
+	printf("Employee Salary: %.2lf\n", e->salary);
 	fflush(stdout);
 }

--- a/employee/read_only.c
+++ b/employee/read_only.c
@@ -1,29 +1,31 @@
 /* This program is very similar to "full_privileges.c"
  * but here we set the permissions of the capability
  * to LOAD, i.e. read-only. So the user is not allowed to
- * change the salary.
+ * change, e.g. the salary.
  */
 
 #include "../include/common.h"
 #include "include/employee.h"
+#include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
 int main()
 {
-	struct employee employee = {0, "Good", "Employee", 55000};
-	double salary = 0.0;
+	struct employee employee = {1000, "Good", "Employee", 55000.0};
+	printf("--- EMPLOYEE ---\n");
 	// set the permissions to read-only
 	struct employee *ro_employee = set_read_only(&employee);
-	inspect_pointer(ro_employee);
+	assert((cheri_perms_get(ro_employee) & CHERI_PERM_STORE) == 0);
 	print_details(ro_employee);
-	printf("The struct is read-only so trying to change the salary will make the program crash...");
-	printf("\nInsert the new salary for this employee: \n");
+	double new_salary = 65000.0;
+	printf(
+		"\nThe struct is read-only so trying to change the salary to %.2lf will make the program "
+		"crash...\n",
+		new_salary);
 	fflush(stdout);
-	scanf("%lf", &salary);
-
-	change_salary(ro_employee, salary);
+	change_salary(ro_employee, new_salary);
 	print_details(ro_employee);
 }
 
@@ -32,11 +34,7 @@ int main()
  */
 struct employee *set_read_only(struct employee *e)
 {
-	char *ro_name = (char *)cheri_perms_and(e->name, CHERI_PERM_LOAD);
-	char *ro_surname = (char *)cheri_perms_and(e->surname, CHERI_PERM_LOAD);
-	struct employee *ro_employee =
-		(struct employee *)cheri_perms_and(e, CHERI_PERM_LOAD || CHERI_PERM_LOAD_CAP);
-	ro_employee->name = ro_name;
-	ro_employee->surname = ro_surname;
-	return ro_employee;
+	e->name = (char *)cheri_perms_and(e->name, CHERI_PERM_LOAD);
+	e->surname = (char *)cheri_perms_and(e->surname, CHERI_PERM_LOAD);
+	return (struct employee *)cheri_perms_and(e, CHERI_PERM_LOAD | CHERI_PERM_LOAD_CAP);
 }


### PR DESCRIPTION
Actual tests did not detect this issue because they only test the Exception, NOT where it is caused.
Trying to access more than a member of the read-only struct cause an "In-Address Security Exception" due to:

```
// $HOME/cheri/cheribsd/lib/libc/string/strlen.c:[144-157]
...

#else /* __CHERI_PURE_CAPABILITY__ */
size_t
strlen(const char *str)
{
	const char *p;

	p = str;
// HERE, line 153 accessing *p raises the Exception
	while (*p != '\0')
		p++;

	return (p - str);
}
#endif /* __CHERI_PURE_CAPABILITY__ */
```

This draft PR asks for any pieces of advice or wants to be a mean to discuss the issue. Thanks!