### PR TITLE
Create `bin` dir in Makefile

### DIFF
--- a/Makefile.morello
+++ b/Makefile.morello
@@ -14,9 +14,11 @@ examples := $(patsubst %.c,bin/%,$(cfiles)) $(patsubst %.cpp,bin/%,$(cfiles))
 all: $(examples)
 	
 bin/%: %.c
+	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) $< -o $@
 
 bin/%: %.cpp
+	@mkdir -p $(@D)
 	$(CXX) $(CFLAGS) $< -o $@
 
 .SECONDEXPANSION:

--- a/Makefile.riscv64
+++ b/Makefile.riscv64
@@ -14,9 +14,11 @@ examples := $(patsubst %.c,bin/%,$(cfiles)) $(patsubst %.cpp,bin/%,$(cfiles))
 all: $(examples)
 	
 bin/%: %.c
+	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) $< -o $@
 
 bin/%: %.cpp
+	@mkdir -p $(@D)
 	$(CXX) $(CFLAGS) $< -o $@
 
 .SECONDEXPANSION:

--- a/employee/Makefile
+++ b/employee/Makefile
@@ -10,9 +10,11 @@ full_privileges := full_privileges.c employee.c
 all: bin/full_privileges bin/read_only
 
 bin/read_only: $(read_only)
+	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) $^ -o $@
 
 bin/full_privileges: $(full_privileges)
+	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) $^ -o $@
 
 run:


### PR DESCRIPTION
- The user should not be confused by not having a `bin` dir;
- The build should not fail because a `bin` dir does not exist.