### PR TITLE
Modified and refactored "inspect_pointer"

### DIFF
--- a/allocate.c
+++ b/allocate.c
@@ -18,5 +18,5 @@ int main()
 	}
 
 	void *memory = malloc(size);
-	inspect_pointer(memory);
+	pp_cap(memory);
 }

--- a/bounds-cxx.cpp
+++ b/bounds-cxx.cpp
@@ -8,7 +8,7 @@ int main()
 	std::vector<int> list = {1, 2, 3, 4};
 	for (unsigned int i = 0; i <= 16; i++)
 	{
-		inspect_pointer(&list[i]);
+		pp_cap(&list[i]);
 		std::cout << "Value: " << list[i] << std::endl;
 	}
 }

--- a/bounds.c
+++ b/bounds.c
@@ -18,7 +18,7 @@ int main()
 	uint64_t length = cheri_length_get(typed_array);
 	for (uint32_t counter = 0; counter <= (length / sizeof(int32_t)) + 15; counter++)
 	{
-		inspect_pointer(typed_array + counter);
+		pp_cap(typed_array + counter);
 		// Read value to crash
 		printf("Count: %d, Value: %d\n", counter, *(typed_array + counter));
 	}

--- a/example_allocators/bump_allocator/bad_client.c
+++ b/example_allocators/bump_allocator/bad_client.c
@@ -31,7 +31,7 @@ int main()
 
 	p = (int *)bump_alloc(1 * sizeof(int));
 	if (DEBUG_PRINTF)
-		inspect_pointer(p);
+		pp_cap(p);
 	if (p)
 	{
 		*p = 42;

--- a/example_allocators/bump_allocator/good_client.c
+++ b/example_allocators/bump_allocator/good_client.c
@@ -29,7 +29,7 @@ int main()
 	{
 		int *x = (int *)bump_alloc(1 * sizeof(int));
 		if (DEBUG_PRINTF)
-			inspect_pointer(x);
+			pp_cap(x);
 		if (x)
 		{
 			*x = 42;

--- a/function.c
+++ b/function.c
@@ -50,7 +50,7 @@ int main()
 
 	int c_gcd = gcd(a, b);
 	printf("The gcd of these numbers is: %d\n", c_gcd);
-	inspect_pointer(*gcd);
+	pp_cap(*gcd);
 
 	return 0;
 }

--- a/general_bounds.c
+++ b/general_bounds.c
@@ -25,7 +25,7 @@ int main(int argc, char *argv[])
 	uint64_t length = cheri_getlength(typed_array);
 	for (uint32_t counter = 0; counter <= (length / sizeof(int32_t)) + 11; counter++)
 	{
-		inspect_pointer(typed_array + counter);
+		pp_cap(typed_array + counter);
 		// Read value to crash
 		if (counter == 12)
 		{

--- a/include/common.h
+++ b/include/common.h
@@ -3,6 +3,10 @@
 #include <stdint.h>
 #include <stdio.h>
 
+/*
+ * Print information about a capability
+ */
+
 void inspect_pointer(void *ptr)
 {
 	uint64_t length = cheri_length_get(ptr);
@@ -14,9 +18,13 @@ void inspect_pointer(void *ptr)
 	bool tag = cheri_tag_get(ptr);
 
 	uint64_t offset = cheri_offset_get(ptr);
-	printf("Address: %04lx, Base: %04lx, End: %04lx Flags: %04lx, Length: %04lx, Offset: %04lx, "
-		   "Perms: %04lx, Type: %04lx, Tag: %d\n",
-		   address, base, base + length, flags, length, offset, perms, type, tag);
+
+	printf("*** CAPABILITY INFO for ***\n");
+	printf("%#lp\n", ptr);
+	printf("Tag: %d, Perms: %04lx, Type: %lx, Address: %04lx, Base: %04lx, End: %04lx, Flags: %lx, Length: %04lx, Offset: %04lx\n"
+		   ,
+		   tag, perms, type, address, base, base + length, flags, length, offset);
+	printf("****************************\n");
 }
 
 void error(char *string)

--- a/include/common.h
+++ b/include/common.h
@@ -7,7 +7,7 @@
  * Print information about a capability
  */
 
-void inspect_pointer(void *ptr)
+void pp_cap(void *ptr)
 {
 	uint64_t length = cheri_length_get(ptr);
 	uint64_t address = cheri_address_get(ptr);
@@ -19,12 +19,10 @@ void inspect_pointer(void *ptr)
 
 	uint64_t offset = cheri_offset_get(ptr);
 
-	printf("*** CAPABILITY INFO for ***\n");
-	printf("%#lp\n", ptr);
-	printf("Tag: %d, Perms: %04lx, Type: %lx, Address: %04lx, Base: %04lx, End: %04lx, Flags: %lx, Length: %04lx, Offset: %04lx\n"
-		   ,
+	printf("Capability: %#lp\n", ptr);
+	printf("Tag: %d, Perms: %04lx, Type: %lx, Address: %04lx, Base: %04lx, End: %04lx, Flags: %lx, "
+		   "Length: %04lx, Offset: %04lx\n",
 		   tag, perms, type, address, base, base + length, flags, length, offset);
-	printf("****************************\n");
 }
 
 void error(char *string)

--- a/mmap.c
+++ b/mmap.c
@@ -108,8 +108,8 @@ int main()
 	code = get_executable_block();
 	code = generate_purecap(code);
 
-	inspect_pointer(cheri_getpcc());
-	inspect_pointer(code);
+	pp_cap(cheri_getpcc());
+	pp_cap(code);
 
 	int (*code_function)() = (int (*)())code;
 	int result = code_function();

--- a/seal.c
+++ b/seal.c
@@ -33,7 +33,7 @@ typedef union
 int main()
 {
 	void *pcc = cheri_pcc_get();
-	inspect_pointer(pcc);
+	pp_cap(pcc);
 
 	void *searling_root;
 	if (sysarch(CHERI_GET_SEALCAP, &searling_root) < 0)
@@ -48,14 +48,14 @@ int main()
 	data.arr[1] = 0;
 
 	first = cheri_seal(first, other);
-	inspect_pointer(first);
+	pp_cap(first);
 
 	return 0;
 	for (uint32_t i = 0; i < 64; i++)
 	{
 		data.arr[0] |= (1 << i);
 		printf("i: %d ", i);
-		inspect_pointer(data.ptr);
+		pp_cap(data.ptr);
 		data.arr[0] = 0;
 	}
 }

--- a/setjmp.c
+++ b/setjmp.c
@@ -27,7 +27,7 @@ int main()
 			{
 				printf("[STACK POINTER] ");
 			}
-			inspect_pointer(((void **)buffer)[idx]);
+			pp_cap(((void **)buffer)[idx]);
 		}
 	}
 }

--- a/shared_objects/include/find_sentries.h
+++ b/shared_objects/include/find_sentries.h
@@ -34,7 +34,7 @@ bool scan_range(void *ptr, void *exact)
 					printf("[Range match] ");
 				}
 
-				inspect_pointer(current);
+				pp_cap(current);
 			}
 		}
 	}

--- a/shared_objects/main.c
+++ b/shared_objects/main.c
@@ -45,7 +45,7 @@ void compartments_per_object()
 void unexported_functions()
 {
 	printf("Finding do_work using dlsym (main): ");
-	inspect_pointer(dlsym(NULL, "do_work"));
+	pp_cap(dlsym(NULL, "do_work"));
 	void *function_to_search_for = test();
 	printf("test: %p\n", function_to_search_for);
 

--- a/shared_objects/unexported_function.c
+++ b/shared_objects/unexported_function.c
@@ -21,9 +21,9 @@ __attribute__((visibility("hidden"))) void do_work()
 void *test()
 {
 	printf("Finding do_work using dlsym (lib4):\nptr: ");
-	inspect_pointer(dlsym(NULL, "do_work"));
+	pp_cap(dlsym(NULL, "do_work"));
 	printf("Obtaining a direct pointer to it: \nptr: ");
-	inspect_pointer(&do_work);
+	pp_cap(&do_work);
 	printf("test ptr just to keep it in the pcc:\n ptr: %p\n", &test);
 	printf(" ------- scanning pcc for sealed pointers --------\n");
 	bool found = scan_range(cheri_getpcc(), &do_work);

--- a/stackscan.c
+++ b/stackscan.c
@@ -50,8 +50,8 @@ void scan_range(void *start, void *end)
 
 	void **location = (void **)start;
 	puts("Scanning range: ");
-	inspect_pointer(start);
-	inspect_pointer(end);
+	pp_cap(start);
+	pp_cap(end);
 	puts("\n");
 
 	while (location > end)
@@ -66,7 +66,7 @@ void scan_range(void *start, void *end)
 			{
 				printf("[Executable] ");
 			}
-			inspect_pointer(*location);
+			pp_cap(*location);
 		}
 		location -= 1;
 	}

--- a/timsort/timsort.c
+++ b/timsort/timsort.c
@@ -10,7 +10,7 @@ void insertionSort(bp_array bp)
 	size_t length = (get_length(bp) / sizeof(int)) - base;
 
 	int *arr = get_pointer(bp);
-	inspect_pointer(arr);
+	pp_cap(arr);
 
 	int ix, ixValue, ixP;
 	for (ix = base + 1; ix < (base + length); ix++)


### PR DESCRIPTION
`inspect_pointer` should print basic information explaining the permissions in a human-readable way, e.g. Rxrw.
`inspect_pointer` should have a meaningful name, `pp_cap` as in "pretty-print capability".