### PR TITLE
Restore full privileges by explicitly sealing and unsealing

### DIFF
--- a/employee/Makefile
+++ b/employee/Makefile
@@ -4,7 +4,7 @@ CFLAGS=-fuse-ld=lld --config cheribsd-riscv64-purecap.cfg
 SSHPORT=10021
 export
 
-cfiles := full_privileges.c read_only.c
+cfiles := full_privileges.c read_only.c sealed.c
 employee := $(patsubst %.c,bin/%,$(cfiles))
 
 .PHONY: all run clean

--- a/employee/sealed.c
+++ b/employee/sealed.c
@@ -1,0 +1,43 @@
+/*
+ * Starting from a `read_only` struct, this program
+ * restores full privileges using a previous `sealed`
+ * capabilty.
+ */
+
+#include "../include/common.h"
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/sysctl.h>
+
+int main()
+{
+	// Request special capability `sealcap` from the operating system
+	// in order to use it as key to seal `new_small_salary`
+	void *__capability sealcap;
+	size_t sealcap_size = sizeof(sealcap);
+	if (sysctlbyname("security.cheri.sealcap", &sealcap, &sealcap_size, NULL, 0) < 0)
+	{
+		error("Fatal error. Cannot get `securiy.cheri.sealcap`.");
+		exit(1);
+	}
+	assert(cheri_perms_get(sealcap) & CHERI_PERM_SEAL);
+	uint8_t *new_small_salary;
+	// Seal `new_small_salary` using previously requested `sealcap`
+	new_small_salary = (uint8_t *)malloc(sizeof(uint8_t));
+	new_small_salary = (uint8_t *)cheri_seal(new_small_salary, sealcap);
+	assert(cheri_is_sealed(new_small_salary));
+	uint8_t *small_salary;
+	small_salary = (uint8_t *)malloc(sizeof(uint8_t));
+	assert(cheri_perms_get(small_salary) & (CHERI_PERM_LOAD | CHERI_PERM_STORE));
+	pp_cap(small_salary);
+	// Make `small_salary` read-only
+	small_salary = (uint8_t *)cheri_perms_and(&small_salary, CHERI_PERM_LOAD);
+	assert(cheri_perms_get(small_salary) & CHERI_PERM_LOAD);
+	pp_cap(small_salary);
+	// Restore it to read-write using previously sealed capability `new_small_salary`
+	small_salary = (uint8_t *)cheri_unseal(new_small_salary, sealcap);
+	assert(cheri_perms_get(small_salary) & (CHERI_PERM_LOAD | CHERI_PERM_STORE));
+	pp_cap(small_salary);
+}


### PR DESCRIPTION
Opening this draft PR to discuss if this is how we want to convey the information to the user.
This is just the first part of the `employee sealed` example. I thought to put all the ways to seal/unseal/restore privileges together at first. However, I think that would be better to have three separate smaller programs. This is the first one: explicitly sealing and unsealing. I am not sure that this is what we want.