### PR TITLE
Some minimal code to start a discussion about CInvoke like instructions

### DIFF
--- a/employee/employee-cinvoke.c
+++ b/employee/employee-cinvoke.c
@@ -44,7 +44,7 @@ int main()
 	// qemu system crash:
 	// cheri_utils.h:225 "Should only be used with sentry cap"
 	// ~/cheri/morello-qemu/target/cheri-common/cheri_utils.h
-	// A sentry is already sealed (by definition!) and every consequent call to 
+	// A sentry is already sealed (by definition!) and every subsequent call to 
 	// sealing functions will clear the tag!!!
 	
 

--- a/employee/employee-cinvoke.c
+++ b/employee/employee-cinvoke.c
@@ -12,50 +12,39 @@
 #include <stdlib.h>
 #include <sys/sysctl.h>
 
-struct cheri_object
+typedef struct cheri_object
 {
 	void *__capability datacap;
 	void *__capability codecap;
-};
+} CHERI_OBJECT;
 
-void print_salary(uint8_t salary);
-void print_something();
-void invoke(struct cheri_object * pair);
+CHERI_OBJECT * obj;
+
+// TODO: refactor, move this stuff elsewhere
+void print_salary();
+void ldpblr(struct cheri_object * pair);
 void *__capability seal_immediate(void *__capability cap);
-
 
 int main()
 {
-	struct cheri_object * obj = (struct cheri_object *) malloc(sizeof(struct cheri_object)); 
-	uint8_t *small_salary = (uint8_t *) malloc(sizeof(uint8_t));
+	obj = (CHERI_OBJECT *) malloc(sizeof(CHERI_OBJECT)); 
+	uint16_t salary = 1000;
 	pp_cap(&print_salary);
-	pp_cap(small_salary);
-	obj->codecap = &print_something;
-	*small_salary = 12;
-	obj->datacap = small_salary;
+	pp_cap(&salary);
+	obj->codecap = &print_salary;
+	obj->datacap = &salary;
 	assert(!cheri_is_sealed(obj->datacap));
-	// obj->datacap = seal_immediate(small_salary);
 	assert(cheri_is_sentry(obj->codecap));
 	assert(cheri_is_sealed(obj->codecap));
-	// obj->codecap = seal_immediate(&print_salary);
-	invoke(obj);
-	printf("Just in case, this is small_salary: %d\n", *small_salary);
-
-	// qemu system crash:
-	// cheri_utils.h:225 "Should only be used with sentry cap"
-	// ~/cheri/morello-qemu/target/cheri-common/cheri_utils.h
-	// A sentry is already sealed (by definition!) and every subsequent call to 
-	// sealing functions will clear the tag!!!
+	obj = (CHERI_OBJECT *) seal_immediate(obj);
+	assert(cheri_is_sealed(obj));
 	
+	ldpblr(obj);
 
 	return 0;
 }
 
-inline void invoke(struct cheri_object * cheri_obj){
-	// Data for the function
-	// uint8_t * datacap = (uint8_t *) cheri_obj->datacap;
-	// Function pointer (print_salary) of target function
-	// void (*codecap)(void) =  cheri_obj->codecap;
+inline void ldpblr(struct cheri_object * cheri_obj){
 	asm(
 		"ldpblr c0, [%w[pair]]\n\t"
 		: /* output regs */
@@ -63,7 +52,6 @@ inline void invoke(struct cheri_object * cheri_obj){
   		: "c0","c1","c2","c3","c4","c5","c6","c7","c8","c9","c10","c11","c12","c13","c14","c15","c16","c17","c18","clr","d8","d9","d10","d11","d12","d13","d14","d15"
 		  /* clobbered registers */
 	);
-	
 }
 
 inline void *__capability seal_immediate(void *__capability cap){
@@ -77,12 +65,9 @@ inline void *__capability seal_immediate(void *__capability cap){
 	return sealed_cap;
 }
 
-void print_salary(uint8_t salary){
-	printf("Salary: %d\n", salary);
-	fflush(stdout);
+void print_salary(){	
+	uint16_t * salary_ptr = (obj->datacap);
+	printf("Salary: %d\n", *salary_ptr);
 }
 
-void print_something(){
-	printf("Hello, I have been unsealed!?\n");
-}
 

--- a/employee/employee-cinvoke.c
+++ b/employee/employee-cinvoke.c
@@ -52,11 +52,11 @@ int main()
 	
 	obj->datacap = seal_immediate(small_salary);
 	obj->codecap = seal_immediate(&print_salary);
-	printf("After sealing...\n");
-	pp_cap(&print_salary);
-	pp_cap(small_salary);
-	assert(cheri_is_sealed(obj->datacap));
-	assert(cheri_is_sealed(obj->codecap));
+	// printf("After sealing...\n");
+	// pp_cap(&print_salary);
+	// pp_cap(small_salary);
+	// assert(cheri_is_sealed(obj->datacap));
+	// assert(cheri_is_sealed(obj->codecap));
 
 	invoke(obj);
 
@@ -70,10 +70,10 @@ inline void invoke(struct cheri_object * cheri_obj){
 	// void (*codecap)(void) =  cheri_obj->codecap;
 	asm(
 		"ldpblr c0, [%w[pair]]\n\t"
-		"ret\n\t"
 		: /* output regs */
 		: [pair]"r"(cheri_obj) /* input regs */
-  		: /* all caller-saved regs */
+  		: "c0","c1","c2","c3","c4","c5","c6","c7","c8","c9","c10","c11","c12","c13","c14","c15","c16","c17","c18","clr","d8","d9","d10","d11","d12","d13","d14","d15"
+		  /* clobbered registers */
 	);
 	
 }
@@ -81,15 +81,15 @@ inline void invoke(struct cheri_object * cheri_obj){
 inline void *__capability seal_immediate(void *__capability cap){
 	void *__capability sealed_cap;
 	asm(
-		"seal c1, %w[to_seal], rb\n\t" /* 10 encoded form */
-		: [c1] "=r" (sealed_cap)
+		"seal %0, %w[to_seal], rb\n\t" /* 10 encoded form */
+		: "=r" (sealed_cap)
 		: [to_seal] "r" (cap)
-		: /* all caller-saved regs */
+		: 
 	);
 	return sealed_cap;
 }
 
 void print_salary(uint8_t salary){
 	printf("Salary: %d", salary);
-	fflush(stdout);	
+	fflush(stdout);
 }

--- a/employee/employee-cinvoke.c
+++ b/employee/employee-cinvoke.c
@@ -21,6 +21,8 @@ struct cheri_object
 void print_salary(uint8_t salary);
 void invoke(struct cheri_object * pair);
 
+// TODO SEAL (immediate) for morello
+
 int main()
 {
 
@@ -49,32 +51,37 @@ int main()
 	// assert(cheri_is_sealed(obj->codecap));
 	// assert(cheri_is_sealed(obj));
 
-	// Seal only its parts, i.e. codecap and datacap
-	obj->datacap = cheri_seal(small_salary, sealcap);
-	obj->codecap = cheri_seal(&print_salary, sealcap);
-	assert(cheri_is_sealed(obj->datacap));
-	assert(cheri_is_sealed(obj->codecap));
+	// FIXME: commented to try without sealing
+	obj->datacap = small_salary;
+	obj->codecap = &print_salary;
+	// Seal only its parts, i.e. datacap and codecap
+	// obj->datacap = cheri_seal(small_salary, sealcap);
+	// obj->codecap = cheri_seal(&print_salary, sealcap);
+	// assert(cheri_is_sealed(obj->datacap));
+	// assert(cheri_is_sealed(obj->codecap));
 
 	// FIXME: "Invalid permission for mapped object"
 	invoke(obj);
 
 	// assuming the above line works should we be able to
-	// print_salary(small_salary)?
+	// print_salary(*small_salary)?
 
 	return 0;
 }
 
 inline void invoke(struct cheri_object * cheri_obj){
-	// Function pointer (print_salary) of target function
-	// void (*codecap)(void) =  cheri_obj->codecap;
 	// Data for the function
 	// uint8_t * datacap = (uint8_t *) cheri_obj->datacap;
+	// Function pointer (print_salary) of target function
+	// void (*codecap)(void) =  cheri_obj->codecap;
 	asm(
 		"ldpblr c0, [%w[pair]]\n\t"
+		"ret\n\t"
 		: /* output regs */
 		: [pair]"r"(cheri_obj) /* input regs */
   		: /* all caller-saved regs */
 	);
+	
 }
 
 void print_salary(uint8_t salary){

--- a/employee/employee-cinvoke.c
+++ b/employee/employee-cinvoke.c
@@ -23,7 +23,7 @@ CHERI_OBJECT * obj;
 // TODO: refactor, move this stuff elsewhere
 void print_salary();
 void ldpblr(struct cheri_object * pair);
-void *__capability seal_immediate(void *__capability cap);
+CHERI_OBJECT * seal_immediate_pair(CHERI_OBJECT * obj);
 
 int main()
 {
@@ -36,7 +36,7 @@ int main()
 	assert(!cheri_is_sealed(obj->datacap));
 	assert(cheri_is_sentry(obj->codecap));
 	assert(cheri_is_sealed(obj->codecap));
-	obj = (CHERI_OBJECT *) seal_immediate(obj);
+	obj = seal_immediate_pair(obj);
 	assert(cheri_is_sealed(obj));
 	
 	ldpblr(obj);
@@ -44,25 +44,25 @@ int main()
 	return 0;
 }
 
-inline void ldpblr(struct cheri_object * cheri_obj){
+inline void ldpblr(CHERI_OBJECT * obj){
 	asm(
 		"ldpblr c0, [%w[pair]]\n\t"
 		: /* output regs */
-		: [pair]"r"(cheri_obj) /* input regs */
+		: [pair]"r"(obj) /* input regs */
   		: "c0","c1","c2","c3","c4","c5","c6","c7","c8","c9","c10","c11","c12","c13","c14","c15","c16","c17","c18","clr","d8","d9","d10","d11","d12","d13","d14","d15"
 		  /* clobbered registers */
 	);
 }
 
-inline void *__capability seal_immediate(void *__capability cap){
-	void *__capability sealed_cap;
+inline CHERI_OBJECT * seal_immediate_pair(CHERI_OBJECT * obj){
+	CHERI_OBJECT * sealed_obj;
 	asm(
-		"seal %[sealed_cap], %[cap], rb\n\t"
-		: [sealed_cap] "=C" (sealed_cap)
-		: [cap] "C" (cap)
+		"seal %[sealed_obj], %[obj], lpb\n\t"
+		: [sealed_obj] "=C" (sealed_obj)
+		: [obj] "C" (obj)
 		: 
 	);
-	return sealed_cap;
+	return sealed_obj;
 }
 
 void print_salary(){	

--- a/employee/employee-cinvoke.c
+++ b/employee/employee-cinvoke.c
@@ -49,9 +49,10 @@ int main()
 	// assert(cheri_is_sealed(obj->codecap));
 	// assert(cheri_is_sealed(obj));
 
-	
-	obj->datacap = seal_immediate(small_salary);
-	obj->codecap = seal_immediate(&print_salary);
+	obj->codecap = &print_salary;
+	obj->datacap = small_salary;
+	// obj->datacap = seal_immediate(small_salary);
+	// obj->codecap = seal_immediate(&print_salary);
 	// printf("After sealing...\n");
 	// pp_cap(&print_salary);
 	// pp_cap(small_salary);
@@ -78,18 +79,18 @@ inline void invoke(struct cheri_object * cheri_obj){
 	
 }
 
-inline void *__capability seal_immediate(void *__capability cap){
-	void *__capability sealed_cap;
-	asm(
-		"seal %0, %w[to_seal], rb\n\t" /* 10 encoded form */
-		: "=r" (sealed_cap)
-		: [to_seal] "r" (cap)
-		: 
-	);
-	return sealed_cap;
-}
+// inline void *__capability seal_immediate(void *__capability cap){
+// 	void *__capability sealed_cap;
+// 	asm(
+// 		"seal %0, %w[to_seal], rb\n\t" /* 10 encoded form */
+// 		: "=r" (sealed_cap)
+// 		: [to_seal] "r" (cap)
+// 		: 
+// 	);
+// 	return sealed_cap;
+// }
 
 void print_salary(uint8_t salary){
-	printf("Salary: %d", salary);
+	printf("Salary: %d\n", salary);
 	fflush(stdout);
 }

--- a/employee/employee-cinvoke.c
+++ b/employee/employee-cinvoke.c
@@ -46,7 +46,7 @@ int main()
 	// obj->datacap = small_salary;
 	// // Seal `cheri_object` using previously requested `sealcap`
 	// obj = (struct cheri_object *) cheri_seal(obj, sealcap);
-	assert(cheri_is_sealed(obj->codecap));
+	// assert(cheri_is_sealed(obj->codecap));
 	// assert(cheri_is_sealed(obj));
 
 	// Seal only its parts, i.e. codecap and datacap

--- a/employee/employee-cinvoke.c
+++ b/employee/employee-cinvoke.c
@@ -1,0 +1,84 @@
+/* This program  atomically unseal a pair of capabilities
+ * (code and data) by calling `ldpblr`, i.e.
+ * "Load Pair of capabilities and Branch with Link".
+ * See "ARM Architecture Reference Manual Supplement Morello"
+ * (https://developer.arm.com/documentation/ddi0606/latest).
+ */
+
+#include "../include/common.h"
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/sysctl.h>
+
+struct cheri_object
+{
+	void *__capability codecap;
+	void *__capability datacap;
+};
+
+void print_salary(uint8_t salary);
+void invoke(struct cheri_object * pair);
+
+int main()
+{
+
+	// Request special capability `sealcap` from the operating system
+	// in order to use it as key to seal our capabilities
+	void *__capability sealcap;
+	size_t sealcap_size = sizeof(sealcap);
+	if (sysctlbyname("security.cheri.sealcap", &sealcap, &sealcap_size, NULL, 0) < 0)
+	{
+		error("Fatal error. Cannot get `securiy.cheri.sealcap`.");
+		exit(1);
+	}
+	assert(cheri_perms_get(sealcap) & CHERI_PERM_SEAL);
+	struct cheri_object * obj = (struct cheri_object *) malloc(sizeof(struct cheri_object)); 
+	uint8_t *small_salary = (uint8_t *) malloc(sizeof(uint8_t));
+	// This should copy the OType of `y` and derive `x` as in `x = cheri_type_copy(x, y)
+	// small_salary = cheri_type_copy(small_salary, &print_salary);
+	pp_cap(&print_salary);
+	pp_cap(small_salary);
+
+	// Seal the entire struct
+	// obj->codecap = &print_salary;
+	// obj->datacap = small_salary;
+	// // Seal `cheri_object` using previously requested `sealcap`
+	// obj = (struct cheri_object *) cheri_seal(obj, sealcap);
+	assert(cheri_is_sealed(obj->codecap));
+	// assert(cheri_is_sealed(obj));
+
+	// Seal only its parts, i.e. codecap and datacap
+	obj->codecap = cheri_seal(&print_salary, sealcap);
+	obj->datacap = cheri_seal(small_salary, sealcap);
+	assert(cheri_is_sealed(obj->codecap));
+	assert(cheri_is_sealed(obj->datacap));
+
+	// FIXME: "Invalid permission for mapped object"
+	invoke(obj);
+
+	// assuming the above line works should we be able to
+	// print_salary(small_salary)?
+
+	return 0;
+}
+
+inline void invoke(struct cheri_object * cheri_obj){
+	// Function pointer (print_salary) of target function
+	// void (*codecap)(void) =  cheri_obj->codecap;
+	// Data for the function
+	// uint8_t * datacap = (uint8_t *) cheri_obj->datacap;
+	asm(
+		"ldpblr c0, [%w[pair]]\n\t"
+		: /* output regs */
+		: [pair]"r"(cheri_obj) /* input regs */
+  		: /* all caller-saved regs */
+	);
+}
+
+void print_salary(uint8_t salary){
+	printf("Salary: %d", salary);
+	fflush(stdout);	
+}
+

--- a/employee/employee-cinvoke.c
+++ b/employee/employee-cinvoke.c
@@ -49,15 +49,16 @@ int main()
 	// assert(cheri_is_sealed(obj->codecap));
 	// assert(cheri_is_sealed(obj));
 
-	obj->codecap = &print_salary;
+	// obj->codecap = &print_salary;
 	obj->datacap = small_salary;
+	assert(!cheri_is_sealed(obj->codecap));
 	// obj->datacap = seal_immediate(small_salary);
-	// obj->codecap = seal_immediate(&print_salary);
+	obj->codecap = seal_immediate(&print_salary);
+	assert(cheri_is_sealed(obj->codecap));
 	// printf("After sealing...\n");
 	// pp_cap(&print_salary);
 	// pp_cap(small_salary);
 	// assert(cheri_is_sealed(obj->datacap));
-	// assert(cheri_is_sealed(obj->codecap));
 
 	invoke(obj);
 
@@ -79,16 +80,16 @@ inline void invoke(struct cheri_object * cheri_obj){
 	
 }
 
-// inline void *__capability seal_immediate(void *__capability cap){
-// 	void *__capability sealed_cap;
-// 	asm(
-// 		"seal %0, %w[to_seal], rb\n\t" /* 10 encoded form */
-// 		: "=r" (sealed_cap)
-// 		: [to_seal] "r" (cap)
-// 		: 
-// 	);
-// 	return sealed_cap;
-// }
+inline void *__capability seal_immediate(void *__capability cap){
+	void *__capability sealed_cap;
+	asm(
+		"seal %w[sealed_cap], %w[cap], rb\n\t"
+		: [sealed_cap] "=r" (sealed_cap)
+		: [cap] "r" (cap)
+		: 
+	);
+	return sealed_cap;
+}
 
 void print_salary(uint8_t salary){
 	printf("Salary: %d\n", salary);

--- a/employee/employee-cinvoke.c
+++ b/employee/employee-cinvoke.c
@@ -38,6 +38,7 @@ int main()
 	assert(cheri_is_sealed(obj->codecap));
 	obj = seal_immediate_pair(obj);
 	assert(cheri_is_sealed(obj));
+	pp_cap(obj);
 	
 	ldpblr(obj);
 
@@ -46,10 +47,10 @@ int main()
 
 inline void ldpblr(CHERI_OBJECT * obj){
 	asm(
-		"ldpblr c0, [%w[pair]]\n\t"
+		"ldpblr c29, [%w[obj]]\n\t"
 		: /* output regs */
-		: [pair]"r"(obj) /* input regs */
-  		: "c0","c1","c2","c3","c4","c5","c6","c7","c8","c9","c10","c11","c12","c13","c14","c15","c16","c17","c18","clr","d8","d9","d10","d11","d12","d13","d14","d15"
+		: [obj]"r"(obj) /* input regs */
+  		: "c29","c0","c1","c2","c3","c4","c5","c6","c7","c8","c9","c10","c11","c12","c13","c14","c15","c16","c17","c18","clr","d8","d9","d10","d11","d12","d13","d14","d15"
 		  /* clobbered registers */
 	);
 }

--- a/employee/employee-cinvoke.c
+++ b/employee/employee-cinvoke.c
@@ -14,8 +14,8 @@
 
 struct cheri_object
 {
-	void *__capability codecap;
 	void *__capability datacap;
+	void *__capability codecap;
 };
 
 void print_salary(uint8_t salary);
@@ -50,10 +50,10 @@ int main()
 	// assert(cheri_is_sealed(obj));
 
 	// Seal only its parts, i.e. codecap and datacap
-	obj->codecap = cheri_seal(&print_salary, sealcap);
 	obj->datacap = cheri_seal(small_salary, sealcap);
-	assert(cheri_is_sealed(obj->codecap));
+	obj->codecap = cheri_seal(&print_salary, sealcap);
 	assert(cheri_is_sealed(obj->datacap));
+	assert(cheri_is_sealed(obj->codecap));
 
 	// FIXME: "Invalid permission for mapped object"
 	invoke(obj);


### PR DESCRIPTION
As in title. This simple example should demonstrate how to use `ldpblr`, which, among other experimental features, can be used to automatically unseal a pair of capabilities (codecap, datacap).