### PR TITLE
Some simple interactions with the Default Data Capability register

### DIFF
--- a/hybrid/Makefile.common
+++ b/hybrid/Makefile.common
@@ -1,0 +1,50 @@
+# Set by platform-specific makefiles. For example: ~/cheri/output/sdk
+ifndef SDKBASE
+$(error SDKBASE is not set)
+endif
+
+# For example: morello-purecap
+ifndef PLATFORM
+$(error PLATFORM is not set)
+endif
+
+CC := $(SDKBASE)/bin/clang
+CFORMAT := $(SDKBASE)/bin/clang-format
+
+RUNUSER ?= root
+RUNHOST ?= localhost
+RUNDIR ?=
+CFLAGS ?=
+
+BINDIR := bin/$(PLATFORM)
+CFILES := $(wildcard *.c)
+HFILES := $(wildcard include/*.h)
+BINS := $(patsubst %.c,$(BINDIR)/%,$(CFILES))
+RUNTGTS := $(patsubst $(BINDIR)/%,run-%,$(BINS))
+
+.PHONY: all clang-format clean $(RUNTGTS)
+
+all: $(BINS)
+
+# Remove outputs, but only remove the top-level 'bin/' if it's empty. This
+# mitigates the risk of accidental damage, e.g. if run from a user's home when
+# they have a ~/bin.
+clean:
+	rm -rf $(BINDIR)
+	rmdir bin --ignore-fail-on-non-empty
+
+clang-format:
+	$(CFORMAT) -i $(CFILES) $(HFILES)
+
+$(BINDIR)/%: %.c $(HFILES)
+	@mkdir -p $(BINDIR)
+	$(CC) $(CFLAGS) $< -o $@
+
+$(RUNTGTS): run-%: $(BINDIR)/%
+ifdef SSHPORT
+	scp -P $(SSHPORT) $^ $(RUNUSER)@$(RUNHOST):$(RUNDIR)
+	ssh -p $(SSHPORT) $(RUNUSER)@$(RUNHOST) -t ./$(<F)
+else
+	@echo "'$@' requires SSHPORT to be defined."
+	@false
+endif

--- a/hybrid/Makefile.morello-hybrid
+++ b/hybrid/Makefile.morello-hybrid
@@ -1,0 +1,7 @@
+CHERIBASE ?= $(HOME)/cheri
+SDKBASE ?= $(CHERIBASE)/output/morello-sdk
+CFLAGS := --config cheribsd-morello-hybrid.cfg $(CFLAGS)
+PLATFORM := morello-hybrid
+export
+
+include Makefile.common

--- a/hybrid/basic_ddc.c
+++ b/hybrid/basic_ddc.c
@@ -1,0 +1,31 @@
+/***
+ * This program shows a very basic level of compartmentalisation. It first
+ * `malloc` two blocks, and then flip the DDC to point from one to the other.
+ ***/
+
+#include "../include/common.h"
+#include "include/utils.h"
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#if !defined(__CHERI_CAPABILITY_WIDTH__) || defined(__CHERI_PURE_CAPABILITY__)
+#error "This example only works on CHERI hybrid mode"
+#endif
+
+int main()
+{
+	uint16_t *some_int_ptr = (uint16_t *) malloc(sizeof(uint16_t));
+	*some_int_ptr = 200;
+	assert(cheri_address_get(cheri_ddc_get()) != some_int_ptr);
+	uint32_t *some_other_int_ptr = (uint32_t *) malloc(sizeof(uint32_t));
+	write_ddc((void *__capability) some_other_int_ptr);
+	assert(cheri_address_get(cheri_ddc_get()) != some_int_ptr);
+	assert(cheri_address_get(cheri_ddc_get()) == some_other_int_ptr);
+	// Note: this program is very simple and writing to the DDC in this fashion
+	// would cause a crash if the program were to execute much further.
+	write_ddc((void *__capability) some_int_ptr);
+	assert(cheri_address_get(cheri_ddc_get()) != some_other_int_ptr);
+	assert(cheri_address_get(cheri_ddc_get()) == some_int_ptr);
+	return 0;
+}

--- a/hybrid/ddc_invalid.c
+++ b/hybrid/ddc_invalid.c
@@ -1,0 +1,23 @@
+/***
+ * This program causes an "In-address space security Exception" by clearing the
+ * tag of the capability in the DDC
+ ***/
+
+#include "../include/common.h"
+#include "include/utils.h"
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#if !defined(__CHERI_CAPABILITY_WIDTH__) || defined(__CHERI_PURE_CAPABILITY__)
+#error "This example only works on CHERI hybrid mode"
+#endif
+
+int main()
+{
+	// Before clearing the tag we ensure we have a valid one
+	assert(cheri_tag_get(cheri_ddc_get()));
+	// Clearing the tag will cause the exception
+	write_ddc(cheri_tag_clear(cheri_ddc_get()));
+	return 0;
+}

--- a/hybrid/ddc_null.c
+++ b/hybrid/ddc_null.c
@@ -1,0 +1,23 @@
+/***
+ * This program shows that putting "NULL" into the DDC causes an
+ * "In-address space security exception"
+ ***/
+
+#include "../include/common.h"
+#include "include/utils.h"
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#if !defined(__CHERI_CAPABILITY_WIDTH__) || defined(__CHERI_PURE_CAPABILITY__)
+#error "This example only works on CHERI hybrid mode"
+#endif
+
+int main()
+{
+	// Ensure the DDC contains a valid capability
+	assert(cheri_tag_get(cheri_ddc_get()));
+	// Putting a NULL will cause the exception
+	write_ddc(NULL);
+	return 0;
+}

--- a/hybrid/include/utils.h
+++ b/hybrid/include/utils.h
@@ -1,0 +1,25 @@
+/***
+ * Inline Assembly utility functions to read/write to/from the Default Data
+ * Capability Register (DDC)
+ ***/
+
+#if !defined(__aarch64__)
+#error "This utility functions are Morello only"
+#endif
+
+void write_ddc(void *__capability cap);
+void *__capability read_ddc();
+
+// Write a capability to the DDC
+inline void write_ddc(void *__capability cap)
+{
+	asm("MSR DDC, %[cap]\n\t" : : [cap] "C"(cap) : "memory");
+}
+
+// Read a capability from the DDC
+inline void *__capability read_ddc()
+{
+	void *__capability ddc_cap;
+	asm("MRS %[ddc_cap], DDC\n\t" : [ddc_cap] "=C"(ddc_cap) : :);
+	return ddc_cap;
+}

--- a/include/common.h
+++ b/include/common.h
@@ -7,7 +7,7 @@
  * Print information about a capability
  */
 
-void pp_cap(void *ptr)
+void pp_cap(void *__capability ptr)
 {
 	uint64_t length = cheri_length_get(ptr);
 	uint64_t address = cheri_address_get(ptr);


### PR DESCRIPTION
This PR shows some simple interactions with the DDC:

- basic_ddc.c: very basic compartment switching
- ddc_null.c: crash when writing NULL
- ddc_invalid.c: crash when writing an invalid capability