### PR TITLE
Typo fix in Makefile.vars

### DIFF
--- a/build/Makefile.vars.morello-purecap
+++ b/build/Makefile.vars.morello-purecap
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 The CapableVMs "CHERI Examples" Contributors.
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-# Common configuration for 'riscv64-purecap' platforms.
+# Common configuration for 'morello-purecap' platforms.
 # This should not be invoked directly.
 
 CHERIBASE ?= $(HOME)/cheri


### PR DESCRIPTION
A quick typo I found while working on the other PR. A comment stating "riscv64" instead of "morello" in a morello Makefile. I had missed this in my review.