### PR TITLE
fixup typo in README build instructions, example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ and `RUNHOST` can also be specified if required, but default to `root` and
 For example:
 
 ```
-$ SSH_PORT=12345 make -f Makefile.morello-purecap run-seal
+$ SSHPORT=12345 make -f Makefile.morello-purecap run-seal
 ```


### PR DESCRIPTION
I followed @jacobbramley 's build instructions but there was an extraneous underscore in SSH_PORT