### PR TITLE
DDC switch sentry update

### DIFF
--- a/hybrid/ddc_compartment_switching/ddc_compartment_switching_sentry.c
+++ b/hybrid/ddc_compartment_switching/ddc_compartment_switching_sentry.c
@@ -28,13 +28,9 @@ int main()
 	size_t compartment_size = 2000;
 	simple_block[1900] = 80;
 
-	// Make the function within the sentry explicitly executable by
-	// inheriting the PCC executable permission
-	void *__capability switch_exec =
-		cheri_perms_and((void *__capability) switch_compartment,
-						cheri_perms_get(cheri_pcc_get()) | CHERI_PERM_EXECUTE);
 	// Wrap our function in a sentry
-	int (*__capability wrap_fn)(void *, size_t) = cheri_sentry_create(switch_exec);
+	int (*__capability wrap_fn)(void *, size_t) =
+		cheri_sentry_create((void *__capability) switch_compartment);
 
 	assert(cheri_is_valid(wrap_fn));
 	assert(cheri_is_sentry(wrap_fn));


### PR DESCRIPTION
The example showing compartment switching with sentries had redundant
code. We do not need to explicitly grant execution permission to the
function wrapped by the sentry, as this exists.

The issue before was casting the wrapped function pointer to a `void*`,
rather than directly to `void* __capability`, which removed the
necessary permissions.