### PR TITLE
Add utility function and assertions to verify PCC bounds in shared objects

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -8,6 +8,7 @@ set -e
 
 export CHERIBASE=~/cheri
 CHERIBUILD=~/build
+export TEST_TARGET=$1
 
 echo "Checking clang-format..."
 # Note that `sdk` and `morello-sdk` contain different versions of clang-format,
@@ -31,27 +32,47 @@ echo "Checking that all the hybrid examples build on Morello..."
 platform='morello-hybrid'
 for dir in hybrid hybrid/ddc_compartment_switching; do
     pushd "$dir"
-        make -f Makefile.$platform clean
-        make -f Makefile.$platform all
+    make -f Makefile.$platform clean
+    make -f Makefile.$platform all
     popd
 done
 
 export SSHPORT=10021
 export PYTHONPATH="$CHERIBUILD"/test-scripts
 
-echo "Running tests for 'morello-hybrid' using QEMU..."
-args=(
-    --architecture morello-hybrid
-    # Qemu System to use
-    --qemu-cmd $HOME/cheri/output/morello-sdk/bin/qemu-system-morello
-    --bios edk2-aarch64-code.fd
-    --disk-image $HOME/cheri/output/cheribsd-morello-hybrid.img
-    # Required build-dir in CheriBSD
-    --build-dir .
-    --ssh-port $SSHPORT
-    --ssh-key $HOME/.ssh/id_ed25519.pub
+if [ "$1" = "riscv64" ]; then
+    echo "Running tests for 'riscv64-purecap' using QEMU."
+    args=(
+        --architecture riscv64
+        # Qemu System to use
+        --qemu-cmd $HOME/cheri/output/sdk/bin/qemu-system-riscv64cheri
+        --kernel $HOME/cheri/output/rootfs-riscv64-purecap/boot/kernel/kernel
+        --bios bbl-riscv64cheri-virt-fw_jump.bin
+        --disk-image $HOME/cheri/output/cheribsd-riscv64-purecap.img
+        # Required build-dir in CheriBSD
+        --build-dir .
+        --ssh-port $SSHPORT
+        --ssh-key $HOME/.ssh/id_ed25519.pub
     )
-BUILDBOT_PLATFORM=morello-hybrid python3 tests/run_cheri_examples.py "${args[@]}"
+    BUILDBOT_PLATFORM=riscv64-purecap python3 tests/run_cheri_examples.py "${args[@]}"
+elif [ "$1" = "morello-hybrid" ]; then
+    echo "Running tests for 'morello-hybrid' using QEMU..."
+    args=(
+        --architecture morello-hybrid
+        # Qemu System to use
+        --qemu-cmd $HOME/cheri/output/morello-sdk/bin/qemu-system-morello
+        --bios edk2-aarch64-code.fd
+        --disk-image $HOME/cheri/output/cheribsd-morello-hybrid.img
+        # Required build-dir in CheriBSD
+        --build-dir .
+        --ssh-port $SSHPORT
+        --ssh-key $HOME/.ssh/id_ed25519.pub
+    )
+    BUILDBOT_PLATFORM=morello-hybrid python3 tests/run_cheri_examples.py "${args[@]}"
+else
+    echo "$1 not supported (yet)."
+    exit 1
+fi
 
 # TODO: Run tests for `morello-purecap` and `riscv64-purecap` too
 # This is related to https://github.com/CTSRD-CHERI/cheribuild/issues/182

--- a/shared_objects/build/Makefile.shared_objects
+++ b/shared_objects/build/Makefile.shared_objects
@@ -16,7 +16,7 @@ endif
 
 CFILES := $(wildcard *.c)
 HFILES := $(wildcard include/*.h) $(wildcard ../include/*.h)
-LIBNAMES := static_variable unexported_function compartment_per_object
+LIBNAMES := static_variable unexported_function compartment_per_object static_function
 SOFILES := $(patsubst %,$(BINDIR)/lib%.so,$(LIBNAMES))
 
 .PHONY: all clang-format clean run-shared_objects
@@ -32,15 +32,15 @@ clean:
 		rmdir bin --ignore-fail-on-non-empty; \
 	fi
 
-$(BINDIR)/main: main.c $(HFILES) $(SOFILES)
+$(BINDIR)/%: %.c $(HFILES) $(SOFILES)
 	@mkdir -p $(BINDIR)
-	$(CC) $(CFLAGS) -fpie -L $(BINDIR) -Wl,-rpath,. -ldl $(patsubst %,-l%,$(LIBNAMES)) $< -o $(BINDIR)/main
+	$(CC) $(CFLAGS) -fpie -L $(BINDIR) -Wl,-rpath,. -ldl $(patsubst %,-l%,$(LIBNAMES)) $< -o $@
 
 $(BINDIR)/lib%.so: %.c $(HFILES)
 	@mkdir -p $(BINDIR)
 	$(CC) $(CFLAGS) -fPIC -shared $< -o $@
 
-run-shared_objects: $(BINDIR)/main $(SOFILES)
+run-shared_objects-%: $(BINDIR)/% $(SOFILES)
 ifdef SSHPORT
 	ssh $(SSH_OPTIONS) -p $(SSHPORT) $(RUNUSER)@$(RUNHOST) 'mkdir -p $(RUNDIR)'
 	scp $(SCP_OPTIONS) -P $(SSHPORT) $^ $(RUNUSER)@$(RUNHOST):$(RUNDIR)

--- a/shared_objects/include/find_sentries.h
+++ b/shared_objects/include/find_sentries.h
@@ -1,3 +1,8 @@
+/*
+ * Some utility functions to check range of addresses
+ * and whether a capability is the only one in the PCC
+ */
+
 #include <stdbool.h>
 
 #include "../../include/common.h"
@@ -38,4 +43,16 @@ bool scan_range(void *ptr, void *exact)
 		}
 	}
 	return found;
+}
+
+/**
+ * Check whether ptr1 and ptr2 share the same base and
+ * bounds. If the latter is true and, e.g., ptr1 is the PCC,
+ * then the PCC contains only ptr2.
+ */
+bool base_and_bounds_eq(void *__capability ptr1, void *__capability ptr2)
+{
+	void *__capability pcc = cheri_pcc_get();
+	return cheri_base_get(ptr1) == cheri_base_get(ptr2) &&
+		   cheri_length_get(ptr1) == cheri_length_get(ptr2);
 }

--- a/shared_objects/include/static_function.h
+++ b/shared_objects/include/static_function.h
@@ -1,0 +1,5 @@
+static int static_function();
+static double another_static_function();
+void non_static_fun();
+void non_static_fun2();
+void check_static_and_non_static();

--- a/shared_objects/main.c
+++ b/shared_objects/main.c
@@ -10,6 +10,7 @@
 
 #include "include/compartment_per_object.h"
 #include "include/find_sentries.h"
+#include "include/static_function.h"
 #include "include/static_variable.h"
 #include "include/unexported_function.h"
 

--- a/shared_objects/pcc_bounds_check_main.c
+++ b/shared_objects/pcc_bounds_check_main.c
@@ -1,0 +1,14 @@
+/**
+ * Check whether the PCC covers only one function
+ * in shared objects (static_variable, static_function)
+ */
+#include "include/find_sentries.h"
+#include "include/static_function.h"
+#include "include/static_variable.h"
+
+int main()
+{
+	increment();
+	check_static_and_non_static();
+	return 0;
+}

--- a/shared_objects/static_function.c
+++ b/shared_objects/static_function.c
@@ -1,0 +1,39 @@
+#include "include/static_function.h"
+#include "include/find_sentries.h"
+#include <assert.h>
+#include <stdio.h>
+
+static int static_function()
+{
+	assert(base_and_bounds_eq(cheri_pcc_get(), &static_function));
+	return 0;
+}
+
+static double another_static_function()
+{
+	assert(base_and_bounds_eq(cheri_pcc_get(), &another_static_function));
+	return 1.0;
+}
+
+void non_static_fun()
+{
+	assert(base_and_bounds_eq(cheri_pcc_get(), &non_static_fun));
+	assert(base_and_bounds_eq(cheri_pcc_get(), &static_function));
+	printf("Called static function with result: %d\n", static_function());
+}
+
+void non_static_fun2()
+{
+	assert(base_and_bounds_eq(cheri_pcc_get(), &non_static_fun2));
+	assert(base_and_bounds_eq(cheri_pcc_get(), &another_static_function));
+	printf("Called another function with result: %f\n", another_static_function());
+}
+
+void check_static_and_non_static()
+{
+	assert(base_and_bounds_eq(cheri_pcc_get(), &non_static_fun));
+	assert(base_and_bounds_eq(cheri_pcc_get(), &static_function));
+	assert(base_and_bounds_eq(cheri_pcc_get(), &non_static_fun2));
+	assert(base_and_bounds_eq(cheri_pcc_get(), &another_static_function));
+	assert(base_and_bounds_eq(cheri_pcc_get(), &check_static_and_non_static));
+}

--- a/shared_objects/static_variable.c
+++ b/shared_objects/static_variable.c
@@ -1,19 +1,26 @@
 /**
  * A basic example showing how CHERI sealed entries can be used to protect data. In this case the
  * cont variable will be inaccessible from the things that link with this shared library.
+ * Furthermore, each sentry when executed will be the only one in the PCC and so will have no
+ * access over its bounds.
  */
 
 #include "include/static_variable.h"
+#include "include/find_sentries.h"
+#include <assert.h>
 
 static int32_t count = -5;
 
 void increment()
 {
 	count += 1;
+	assert(base_and_bounds_eq(cheri_pcc_get(), &increment));
 }
 
 int get_count()
 {
+	assert(base_and_bounds_eq(cheri_pcc_get(), &get_count));
+
 	if (count > 0)
 	{
 		return count;

--- a/tests/run_cheri_examples.py
+++ b/tests/run_cheri_examples.py
@@ -34,7 +34,8 @@ def run_cheri_examples_tests(qemu: boot_cheribsd.QemuCheriBSDInstance, args: arg
         boot_cheribsd.set_ld_library_path_with_sysroot(qemu)
     boot_cheribsd.info("Running tests for cheri-examples")
 
-    return os.system("./tests/run_tests.sh") == 0
+    # Run the tests according to the architecture
+    return os.system(f"./tests/run_tests.sh {args.architecture}") == 0
 
 
 if __name__ == '__main__':

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -17,7 +17,7 @@
 # - SSHUSER (defaults to 'root')
 # - SSHHOST (defaults to 'localhost')
 #
-# TODO: Extend this to cover interactive examples and other architectures. 
+# TODO: Extend this to cover interactive examples and other architectures.
 # For now, we just test examples on `morello-hybrid`.
 
 set -e
@@ -56,20 +56,27 @@ function run {
 
 # TODO: `mmap` also fails, but looks like it is intended to pass.
 
-# TODO: PURECAP tests
-
-# HYBRID TESTS
-# Tests that should fail
-run to_fail hybrid/ddc_compartment_switching ddc_compartment_switching_nok
-run to_fail hybrid ddc_invalid ddc_null
-run to_fail hybrid/compartment_examples/inter_comp_call/secure-try_deref main
-run to_fail hybrid/compartment_examples/inter_comp_call/secure-redirect_clr main
-run to_fail hybrid/compartment_examples/inter_comp_call/secure-update_ddc main
-# Tests that should pass
-run OK hybrid/ddc_compartment_switching ddc_compartment_switching
-run OK hybrid basic_ddc
-run OK hybrid/compartment_examples/inter_comp_call/base main
-run OK hybrid/compartment_examples/inter_comp_call/secure main
+# PURECAP tests
+# TODO: add previous examples
+if [ "$1" = "riscv64" ]; then
+    run OK shared_objects shared_objects-pcc_bounds_check_main
+elif [ "$1" = "morello-hybrid" ]; then
+    # HYBRID TESTS
+    # Tests that should fail
+    run to_fail hybrid/ddc_compartment_switching ddc_compartment_switching_nok
+    run to_fail hybrid ddc_invalid ddc_null
+    run to_fail hybrid/compartment_examples/inter_comp_call/secure-try_deref main
+    run to_fail hybrid/compartment_examples/inter_comp_call/secure-redirect_clr main
+    run to_fail hybrid/compartment_examples/inter_comp_call/secure-update_ddc main
+    # Tests that should pass
+    run OK hybrid/ddc_compartment_switching ddc_compartment_switching
+    run OK hybrid basic_ddc
+    run OK hybrid/compartment_examples/inter_comp_call/base main
+    run OK hybrid/compartment_examples/inter_comp_call/secure main
+else
+    echo "$1 not supported (yet)."
+    exit 1
+fi
 
 # TODO: 'timsort' works, but takes a very long time. Is it useful to test a
 # smaller data set?


### PR DESCRIPTION
Draft PR to enhance what we already have in the shared_objects example. If you like the idea, I'll add the other tests/more tests we have discussed. Basically, I do with assertions what I checked in `gdb`.