### PR TITLE
Add examples that write capabilities to `mmap`ed memory.

### DIFF
--- a/capability_sharing/cap-to-file/README.md
+++ b/capability_sharing/cap-to-file/README.md
@@ -1,6 +1,6 @@
 # Read a capability from a file
 
-This example is not automatically built by the top-level makefiles, but are
+This example is not automatically built by the top-level makefiles, but is
 built in a similar manner:
 
 ```

--- a/capability_sharing/leak-capability/README.md
+++ b/capability_sharing/leak-capability/README.md
@@ -19,7 +19,7 @@ it is possible to read a valid capability from a file.
 
 ## Running
 
-This example is not automatically built by the top-level makefiles, but are
+This example is not automatically built by the top-level makefiles, but is
 built in a similar manner:
 
 ```

--- a/capability_sharing/mmap-shared-vs-private/Makefile.morello-purecap
+++ b/capability_sharing/mmap-shared-vs-private/Makefile.morello-purecap
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 The CapableVMs "CHERI Examples" Contributors.
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+include ../../build/Makefile.vars.morello-purecap
+include ../../build/Makefile.vars.common
+include build/Makefile.mmap_shared_vs_private

--- a/capability_sharing/mmap-shared-vs-private/Makefile.riscv64-purecap
+++ b/capability_sharing/mmap-shared-vs-private/Makefile.riscv64-purecap
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 The CapableVMs "CHERI Examples" Contributors.
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+include ../../build/Makefile.vars.riscv64-purecap
+include ../../build/Makefile.vars.common
+include build/Makefile.mmap_shared_vs_private

--- a/capability_sharing/mmap-shared-vs-private/README.md
+++ b/capability_sharing/mmap-shared-vs-private/README.md
@@ -1,0 +1,20 @@
+# Writing capabilities to anonymous and file-backed mappings
+
+These examples demonstrate what happens when you write tagged pointer
+values to various types of memory mappings:
+ * Anonymous private mapping (OK)
+ * Anonymous shared mapping (OK)
+ * File-backed private mapping (OK)
+ * File-backed shared mapping (segfault)
+
+These examples are not automatically built by the top-level makefiles, but are
+built in a similar manner:
+
+```
+$ make -f Makefile.<platform> run-private_anon_main
+$ make -f Makefile.<platform> run-private_file_main
+$ make -f Makefile.<platform> run-shared_anon_main
+$ make -f Makefile.<platform> run-shared_file_main
+```
+
+Refer to the top-level [README][../README.md] for usage details.

--- a/capability_sharing/mmap-shared-vs-private/build/Makefile.mmap_shared_vs_private
+++ b/capability_sharing/mmap-shared-vs-private/build/Makefile.mmap_shared_vs_private
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 The CapableVMs "CHERI Examples" Contributors.
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+# Common Makefile for the mmap_shared_vs_private example.
+# This should not be invoked directly.
+CFLAGS += -I./include
+RUNDIR := $(RUNDIR)/mmap_shared_vs_private
+HFILES := $(wildcard include/*.h) $(wildcard ../include/*.h)
+SHARED_SOURCES := util.c
+
+export
+
+include ../../build/Makefile.simple

--- a/capability_sharing/mmap-shared-vs-private/include/util.h
+++ b/capability_sharing/mmap-shared-vs-private/include/util.h
@@ -1,0 +1,28 @@
+#ifndef __MMAP_SHARED_VS_PRIVATE_UTIL_H__
+#define __MMAP_SHARED_VS_PRIVATE_UTIL_H__
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define MMAP_SIZE 4096
+#define INIT_TEST_CASE(prot_in, flags_in, fd_in)                                                   \
+	{                                                                                              \
+		.prot = prot_in, .flags = flags_in, .fd = fd_in,                                           \
+		.details = "flags = " #flags_in ", prot = " #prot_in                                       \
+	}
+
+typedef struct mmap_test_case
+{
+	/* The memory protection flags */
+	int prot;
+	/* The visibility flags */
+	int flags;
+	/* The file descriptor, if a file mapping was requested. */
+	int fd;
+	/* A string describing the mapping (used for debugging). */
+	char *details;
+} mmap_test_case_t;
+
+int run_mmap_test(mmap_test_case_t);
+
+#endif // __MMAP_SHARED_VS_PRIVATE_UTIL_H__

--- a/capability_sharing/mmap-shared-vs-private/private_anon_main.c
+++ b/capability_sharing/mmap-shared-vs-private/private_anon_main.c
@@ -1,0 +1,11 @@
+#include "util.h"
+
+#include <stdio.h>
+#include <sys/mman.h>
+
+int main(int argc, char **argv)
+{
+	mmap_test_case_t test = INIT_TEST_CASE(PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1);
+
+	return run_mmap_test(test);
+}

--- a/capability_sharing/mmap-shared-vs-private/private_file_main.c
+++ b/capability_sharing/mmap-shared-vs-private/private_file_main.c
@@ -1,0 +1,28 @@
+#include "util.h"
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/mman.h>
+
+int main(int argc, char **argv)
+{
+	FILE *f = tmpfile();
+
+	if (f == NULL)
+	{
+		perror("failed to create file");
+		return 1;
+	}
+
+	int errno;
+
+	// Make sure the file is large enough
+	if ((errno = posix_fallocate(fileno(f), 0, MMAP_SIZE)))
+	{
+		fprintf(stderr, "failed to extend file (error code: %d)\n", errno);
+	}
+
+	mmap_test_case_t test = INIT_TEST_CASE(PROT_READ | PROT_WRITE, MAP_PRIVATE, fileno(f));
+
+	return run_mmap_test(test);
+}

--- a/capability_sharing/mmap-shared-vs-private/shared_anon_main.c
+++ b/capability_sharing/mmap-shared-vs-private/shared_anon_main.c
@@ -1,0 +1,11 @@
+#include "util.h"
+
+#include <stdio.h>
+#include <sys/mman.h>
+
+int main(int argc, char **argv)
+{
+	mmap_test_case_t test = INIT_TEST_CASE(PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1);
+
+	return run_mmap_test(test);
+}

--- a/capability_sharing/mmap-shared-vs-private/shared_file_main.c
+++ b/capability_sharing/mmap-shared-vs-private/shared_file_main.c
@@ -1,0 +1,29 @@
+#include "util.h"
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/mman.h>
+
+int main(int argc, char **argv)
+{
+	FILE *f = tmpfile();
+
+	if (f == NULL)
+	{
+		perror("failed to create file");
+		return 1;
+	}
+
+	int errno;
+
+	// Make sure the file is large enough
+	if ((errno = posix_fallocate(fileno(f), 0, MMAP_SIZE)))
+	{
+		fprintf(stderr, "failed to extend file (error code: %d)\n", errno);
+	}
+
+	mmap_test_case_t test = INIT_TEST_CASE(PROT_READ | PROT_WRITE, MAP_SHARED, fileno(f));
+
+	// Writing a capability to a file-backed mapping will trigger a segfault:
+	return run_mmap_test(test);
+}

--- a/capability_sharing/mmap-shared-vs-private/util.c
+++ b/capability_sharing/mmap-shared-vs-private/util.c
@@ -1,0 +1,46 @@
+#include "util.h"
+
+#include <cheriintrin.h>
+
+#include <cheri/cheric.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+
+static void *create_mmap(mmap_test_case_t test)
+{
+	printf("creating mapping (%s, fd = %d)\n", test.details, test.fd);
+
+	void *addr = mmap(NULL, MMAP_SIZE, test.prot, test.flags, test.fd, 0);
+
+	if (addr == MAP_FAILED)
+	{
+		perror("failed to mmap");
+		return NULL;
+	}
+
+	printf("mmap succeeded (requested length = %d, actual length = %zu): %#lp\n", MMAP_SIZE,
+		   cheri_getlength(addr), addr);
+
+	return addr;
+}
+
+int run_mmap_test(mmap_test_case_t test)
+{
+	uintptr_t *addr = (uintptr_t *) create_mmap(test);
+
+	int x = 0;
+	uintptr_t cap = (uintptr_t) &x;
+	*addr = cap;
+
+	printf("original capability: %#lp\n", (void *) cap);
+	printf("stored capability: %#lp\n", (void *) *addr);
+
+	if (munmap(addr, MMAP_SIZE))
+	{
+		perror("failed to unmap");
+		return 1;
+	}
+
+	return 0;
+}

--- a/capability_sharing/read-cap-from-file/README.md
+++ b/capability_sharing/read-cap-from-file/README.md
@@ -1,6 +1,6 @@
 # Read a capability from a file
 
-This example is not automatically built by the top-level makefiles, but are
+This example is not automatically built by the top-level makefiles, but is
 built in a similar manner:
 
 ```

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -58,10 +58,16 @@ function run {
 # PURECAP tests
 # TODO: add previous examples
 if [ "$1" = "riscv64" ] || [ "$1" = "morello-purecap" ]; then
+    # Tests that should pass
     run OK shared_objects shared_objects-pcc_bounds_check_main
     run OK capability_sharing/cap-to-file cap_to_file
     run OK capability_sharing/read-cap-from-file read-cap-from-file
     run OK capability_sharing/leak-capability leak-capability
+    run OK capability_sharing/mmap-shared-vs-private private_anon_main
+    run OK capability_sharing/mmap-shared-vs-private private_file_main
+    run OK capability_sharing/mmap-shared-vs-private shared_anon_main
+    # Tests that should fail
+    run to_fail capability_sharing/mmap-shared-vs-private shared_file_main
 elif [ "$1" = "morello-hybrid" ]; then
     # HYBRID TESTS
     # Tests that should fail


### PR DESCRIPTION
Add examples that write capabilities to `mmap`ed memory.

These examples demonstrate what happens when you write tagged pointer values to various types of memory mappings:
   * Anonymous private mapping (OK)
   * Anonymous shared mapping (OK)
   * File-backed private mapping (OK)
   * File-backed shared mapping (segfault)