### PR TITLE
A couple of examples which fail to leak capabilities using pipes.

### DIFF
--- a/capability_sharing/read-cap-from-pipe-with-sh/Makefile.morello-purecap
+++ b/capability_sharing/read-cap-from-pipe-with-sh/Makefile.morello-purecap
@@ -1,0 +1,6 @@
+# Copyright (c) 2022 The CapableVMs "CHERI Examples" Contributors.
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+include ../../build/Makefile.vars.morello-purecap
+include ../../build/Makefile.vars.common
+include build/Makefile.read-cap-from-pipe-with-sh

--- a/capability_sharing/read-cap-from-pipe-with-sh/Makefile.riscv64-purecap
+++ b/capability_sharing/read-cap-from-pipe-with-sh/Makefile.riscv64-purecap
@@ -1,0 +1,6 @@
+# Copyright (c) 2022 The CapableVMs "CHERI Examples" Contributors.
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+include ../../build/Makefile.vars.riscv64-purecap
+include ../../build/Makefile.vars.common
+include build/Makefile.read-cap-from-pipe-with-sh

--- a/capability_sharing/read-cap-from-pipe-with-sh/README.md
+++ b/capability_sharing/read-cap-from-pipe-with-sh/README.md
@@ -1,0 +1,19 @@
+# Reading and writing capabilities to a pipe
+
+The setup consists of two processes spawned by the shell:
+  * a writer process (whose stdout is redirected to a pipe by the shell), which
+    writes a capability to stdout
+  * a reader process which reads the capability from stdin (its stdin is redirected
+    to the same pipe the writer process writes to). The reader processs reads an
+    invalid capability
+
+## Running
+
+This example is not automatically built by the top-level makefiles, but is
+built in a similar manner:
+
+```
+$ make -f Makefile.<platform> run-read-cap-from-pipe-with-sh
+```
+
+Refer to the top-level [README][../README.md] for usage details.

--- a/capability_sharing/read-cap-from-pipe-with-sh/build/Makefile.read-cap-from-pipe-with-sh
+++ b/capability_sharing/read-cap-from-pipe-with-sh/build/Makefile.read-cap-from-pipe-with-sh
@@ -1,0 +1,39 @@
+# Copyright (c) 2022 The CapableVMs "CHERI Examples" Contributors.
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+# Common Makefile for the read-cap-from-pipe-with-sh examples.
+# This should not be invoked directly.
+
+ifdef RUNDIR
+RUNDIR := $(RUNDIR)/read-cap-from-pipe-with-sh
+else
+RUNDIR := read-cap-from-pipe-with-sh
+endif
+
+HFILES := $(wildcard include/*.h) $(wildcard ../include/*.h)
+export
+
+RUN_SH := ./run.sh
+
+include ../../build/Makefile.simple
+
+.PHONY: scp-run-sh
+
+run-read-cap-from-pipe-with-sh: $(BINS) scp-run-sh
+ifdef RUNDIR
+	scp $(SCP_OPTIONS) -P $(SSHPORT) $(BINS) $(RUNUSER)@$(RUNHOST):$(RUNDIR)
+	ssh $(SSH_OPTIONS) -p $(SSHPORT) $(RUNUSER)@$(RUNHOST) 'cd $(RUNDIR) && $(RUN_SH)'
+else
+	scp $(SCP_OPTIONS) -P $(SSHPORT) $(BINS) $(RUNUSER)@$(RUNHOST):
+	ssh $(SSH_OPTIONS) -p $(SSHPORT) $(RUNUSER)@$(RUNHOST) '$(RUN_SH)'
+endif
+
+scp-run-sh:
+ifdef RUNDIR
+	ssh $(SSH_OPTIONS) -p $(SSHPORT) $(RUNUSER)@$(RUNHOST) 'mkdir -p $(RUNDIR)'
+	scp $(SCP_OPTIONS) -P $(SSHPORT) $(RUN_SH) $(RUNUSER)@$(RUNHOST):$(RUNDIR)
+	ssh $(SSH_OPTIONS) -p $(SSHPORT) $(RUNUSER)@$(RUNHOST) 'chmod +x $(RUNDIR)/$(RUN_SH)'
+else
+	scp $(SCP_OPTIONS) -P $(SSHPORT) $(RUN_SH) $(RUNUSER)@$(RUNHOST):
+	ssh $(SSH_OPTIONS) -p $(SSHPORT) $(RUNUSER)@$(RUNHOST) 'chmod +x $(RUN_SH)'
+endif

--- a/capability_sharing/read-cap-from-pipe-with-sh/read.c
+++ b/capability_sharing/read-cap-from-pipe-with-sh/read.c
@@ -1,0 +1,49 @@
+/*
+ * An example which fails to "leak" capabilities using Unix pipes.
+ *
+ * The setup consists of two processes:
+ *   * a writer process that writes a capability to stdout, and
+ *   * a reader process that reads the capability written by the writer process. The
+ *     reader processs successfully reads a valid capability
+ *
+ * This file contains the source of the reader process.
+ *
+ */
+#include <cheriintrin.h>
+
+#include <assert.h>
+#include <cheri/cheric.h>
+#include <errno.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/*
+ * Read the value of a capability from stdin.
+ */
+int main(int argc, char **argv)
+{
+	uintptr_t cap = 0;
+	// 0 is not a valid capability
+	assert(!cheri_is_valid((void *) cap));
+
+	freopen(NULL, "rb", stdin);
+
+	size_t n = fread(&cap, sizeof(uintptr_t), 1, stdin);
+
+	if (n != 1)
+	{
+		fprintf(stderr, "read failed: %zu\n", n);
+		return 1;
+	}
+
+	printf("Read capability from stdin: %#lp\n", (void *) cap);
+
+	// As expected, the capability read from stdin is invalid.
+	assert(!cheri_is_valid((void *) cap));
+
+	return 0;
+}

--- a/capability_sharing/read-cap-from-pipe-with-sh/run.sh
+++ b/capability_sharing/read-cap-from-pipe-with-sh/run.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -eou pipefail
+
+# Attempt to share the capability
+./write | ./read

--- a/capability_sharing/read-cap-from-pipe-with-sh/write.c
+++ b/capability_sharing/read-cap-from-pipe-with-sh/write.c
@@ -1,0 +1,47 @@
+/*
+ * An example which fails to "leak" capabilities using Unix pipes.
+ *
+ * The setup consists of two processes spawned by the shell:
+ * * a writer process (whose stdout is redirected to a pipe by the shell), which
+ *   writes a capability to stdout
+ * * a reader process which reads the capability from stdin (its stdin is redirected
+ *   to the same pipe the writer process writes to). The reader processs reads an
+ *   invalid capability
+ *
+ * This file contains the source of the writer process.
+ *
+ */
+#include <cheriintrin.h>
+
+#include <assert.h>
+#include <cheri/cheric.h>
+#include <errno.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/*
+ * Write a capability to stdout.
+ */
+int main(int argc, char **argv)
+{
+	freopen(NULL, "wb", stdout);
+
+	int x = 1;
+	uintptr_t cap = (uintptr_t) &x;
+
+	size_t n = fwrite(&cap, sizeof(uintptr_t), 1, stdout);
+
+	fprintf(stderr, "Wrote capability to stdout: %#lp\n", (void *) cap);
+
+	if (n != 1)
+	{
+		fprintf(stderr, "write failed: %zu\n", n);
+		return 1;
+	}
+
+	return 0;
+}

--- a/capability_sharing/read-cap-from-pipe/Makefile.morello-purecap
+++ b/capability_sharing/read-cap-from-pipe/Makefile.morello-purecap
@@ -1,0 +1,6 @@
+# Copyright (c) 2022 The CapableVMs "CHERI Examples" Contributors.
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+include ../../build/Makefile.vars.morello-purecap
+include ../../build/Makefile.vars.common
+include build/Makefile.read-cap-from-pipe

--- a/capability_sharing/read-cap-from-pipe/Makefile.riscv64-purecap
+++ b/capability_sharing/read-cap-from-pipe/Makefile.riscv64-purecap
@@ -1,0 +1,6 @@
+# Copyright (c) 2022 The CapableVMs "CHERI Examples" Contributors.
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+include ../../build/Makefile.vars.riscv64-purecap
+include ../../build/Makefile.vars.common
+include build/Makefile.read-cap-from-pipe

--- a/capability_sharing/read-cap-from-pipe/README.md
+++ b/capability_sharing/read-cap-from-pipe/README.md
@@ -1,0 +1,19 @@
+# Reading and writing capabilities to a pipe
+
+An example which fails to "leak" capabilities using Unix pipes.
+
+The setup consists of two sibling processes connected to a pipe:
+  * a writer process that writes a capability to the write end of the pipe, and
+  * a reader process that reads the capability written by the writer process
+    to the pipe. The reader processs reads an invalid capability
+
+## Running
+
+This example is not automatically built by the top-level makefiles, but is
+built in a similar manner:
+
+```
+$ make -f Makefile.<platform> run-main
+```
+
+Refer to the top-level [README][../README.md] for usage details.

--- a/capability_sharing/read-cap-from-pipe/build/Makefile.read-cap-from-pipe
+++ b/capability_sharing/read-cap-from-pipe/build/Makefile.read-cap-from-pipe
@@ -1,0 +1,18 @@
+# Copyright (c) 2022 The CapableVMs "CHERI Examples" Contributors.
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+# Common Makefile for the read-cap-from-pipe examples.
+# This should not be invoked directly.
+
+ifdef RUNDIR
+RUNDIR := $(RUNDIR)/read-cap-from-pipe
+else
+RUNDIR := read-cap-from-pipe
+endif
+
+HFILES := $(wildcard include/*.h) $(wildcard ../include/*.h)
+export
+
+RUN_SH := ./run.sh
+
+include ../../build/Makefile.simple

--- a/capability_sharing/read-cap-from-pipe/main.c
+++ b/capability_sharing/read-cap-from-pipe/main.c
@@ -1,0 +1,206 @@
+/*
+ * An example which fails to "leak" capabilities using Unix pipes.
+ *
+ * The setup consists of two sibling processes connected to a pipe:
+ *   * a writer process that writes a capability to the write end of the pipe, and
+ *   * a reader process that reads the capability written by the writer process
+ *     to the pipe. The reader processs reads an invalid capability
+ *
+ */
+#include <cheriintrin.h>
+
+#include <assert.h>
+#include <cheri/cheric.h>
+#include <errno.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define PIPE_READ 0
+#define PIPE_WRITE 1
+#define NUM_CHILDREN 2
+#define NUM_ITERATIONS 10
+#define EXIT_CHILD 0
+#define EXIT_PARENT 1
+
+int read_from_pipe(int fds[2])
+{
+	if (close(fds[PIPE_WRITE]))
+	{
+		perror("failed to close the write end of the pipe");
+		return -1;
+	}
+
+	uintptr_t cap = 0;
+	// 0 is not a valid capability
+	assert(!cheri_is_valid((void *) cap));
+
+	FILE *f = fdopen(fds[PIPE_READ], "r");
+	if (f == NULL)
+	{
+		perror("fdopen fail");
+		return -1;
+	}
+
+	size_t n = fread(&cap, sizeof(uintptr_t), 1, f);
+
+	if (n != 1)
+	{
+		fprintf(stderr, "read failed or EOF: %zu\n", n);
+		return -1;
+	}
+
+	if (fclose(f))
+	{
+		perror("failed to close stream");
+		return -1;
+	}
+
+	printf("Read capability from pipe: %#lp\n", (void *) cap);
+
+	// As expected, the capability read from the pipe is invalid.
+	assert(!cheri_is_valid((void *) cap));
+
+	return 0;
+}
+
+int write_to_pipe(int fds[2])
+{
+	if (close(fds[PIPE_READ]))
+	{
+		perror("failed to close the read end of the pipe");
+		return -1;
+	}
+
+	int x = 1;
+	uintptr_t cap = (uintptr_t) &x;
+
+	fprintf(stderr, "Writing capability to pipe: %#lp\n", (void *) cap);
+
+	FILE *f = fdopen(fds[PIPE_WRITE], "w");
+	if (f == NULL)
+	{
+		perror("fdopen fail");
+		return -1;
+	}
+
+	size_t n = fwrite(&cap, sizeof(uintptr_t), 1, f);
+
+	if (n != 1)
+	{
+		fprintf(stderr, "write failed or EOF: %zu\n", n);
+		return 1;
+	}
+
+	if (fclose(f))
+	{
+		perror("failed to close stream");
+		return 1;
+	}
+
+	return 0;
+}
+
+int spawn_child(int (*child_fn)(int[2]), int fds[2])
+{
+	pid_t pid = fork();
+	switch (pid)
+	{
+	case -1:
+	{
+		perror("failed to spawn child process");
+		return -1;
+	}
+	case 0:
+	{
+		if (child_fn(fds))
+		{
+			return -1;
+		}
+		return 0;
+	}
+	default:
+	{
+		break;
+	}
+	}
+
+	// Parent
+	return pid;
+}
+
+/*
+ * Fork two child processes - one that writes to the pipe (`write_to_pipe`), and
+ * another that reads from the pipe (`read_from_pipe`)
+ */
+int run_pipe_test()
+{
+	int fds[2];
+
+	if (pipe(fds))
+	{
+		perror("failed to create pipe");
+		return -1;
+	}
+
+	// The writer process:
+	int res = spawn_child(write_to_pipe, fds);
+
+	// Only continue if we're the parent and no error occurred.
+	if (res == EXIT_CHILD || res == -1)
+	{
+		return res;
+	}
+
+	// The reader process:
+	res = spawn_child(read_from_pipe, fds);
+
+	// Only continue if we're the parent and no error occurred.
+	if (res == EXIT_CHILD || res == -1)
+	{
+		return res;
+	}
+
+	return EXIT_PARENT;
+}
+
+/*
+ * Write a capability to a pipe.
+ */
+int main(int argc, char **argv)
+{
+	for (size_t i = 0; i < NUM_ITERATIONS; ++i)
+	{
+		switch (run_pipe_test())
+		{
+		case -1:
+		{
+			fprintf(stderr, "failed after %zu iterations\n", i);
+			return -1;
+		}
+		case EXIT_CHILD:
+		{
+			return 0;
+		}
+		default:
+		{
+			// We're the parent process (continue to the next iteration).
+			continue;
+		}
+		}
+	}
+
+	for (size_t i = 0; i < NUM_CHILDREN * NUM_ITERATIONS; ++i)
+	{
+		if (wait(NULL) == -1 && errno != ECHILD)
+		{
+			perror("failed to wait for child");
+			return 1;
+		}
+	}
+
+	return 0;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -66,6 +66,8 @@ if [ "$1" = "riscv64" ] || [ "$1" = "morello-purecap" ]; then
     run OK capability_sharing/mmap-shared-vs-private private_anon_main
     run OK capability_sharing/mmap-shared-vs-private private_file_main
     run OK capability_sharing/mmap-shared-vs-private shared_anon_main
+    run OK capability_sharing/read-cap-from-pipe main
+    run OK capability_sharing/read-cap-from-pipe-with-sh read-cap-from-pipe-with-sh
     # Tests that should fail
     run to_fail capability_sharing/mmap-shared-vs-private shared_file_main
 elif [ "$1" = "morello-hybrid" ]; then


### PR DESCRIPTION
Interestingly enough, I can't reproduce the issue highlighted in my [previous PR](https://github.com/capablevms/cheri-examples/pull/70) using Unix pipes for IPC.

This PR contains 2 examples, both of which seem to work correctly (as in, any capabilities read from a pipe are going to be invalid).

The first example consists of two sibling processes connected to a pipe:
   * a writer process that writes a capability to the write end of the pipe, and
   * a reader process that reads the capability written by the writer process to the pipe. The reader reads an invalid capability

The second example is similar, except it relies on the shell to connect the two processes to a pipe.