### PR TITLE
Fix README typos and copyright year.

### DIFF
--- a/capability_sharing/cap-to-file/README.md
+++ b/capability_sharing/cap-to-file/README.md
@@ -7,4 +7,4 @@ built in a similar manner:
 $ make -f Makefile.<platform> run-cap_to_file
 ```
 
-Refer to the top-level [README][../README.md] for usage details.
+Refer to the top-level [README](../../README.md) for usage details.

--- a/capability_sharing/cap-to-file/build/Makefile.cap-to-file
+++ b/capability_sharing/cap-to-file/build/Makefile.cap-to-file
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 The CapableVMs "CHERI Examples" Contributors.
+# Copyright (c) 2022 The CapableVMs "CHERI Examples" Contributors.
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
 # Common Makefile for the cap-to-file example.

--- a/capability_sharing/leak-capability/README.md
+++ b/capability_sharing/leak-capability/README.md
@@ -26,4 +26,4 @@ built in a similar manner:
 $ make -f Makefile.<platform> run-leak-capability
 ```
 
-Refer to the top-level [README][../README.md] for usage details.
+Refer to the top-level [README](../../README.md) for usage details.

--- a/capability_sharing/leak-capability/build/Makefile.leak-capability
+++ b/capability_sharing/leak-capability/build/Makefile.leak-capability
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 The CapableVMs "CHERI Examples" Contributors.
+# Copyright (c) 2022 The CapableVMs "CHERI Examples" Contributors.
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
 # Common Makefile for the leak-capability examples.

--- a/capability_sharing/mmap-shared-vs-private/README.md
+++ b/capability_sharing/mmap-shared-vs-private/README.md
@@ -17,4 +17,4 @@ $ make -f Makefile.<platform> run-shared_anon_main
 $ make -f Makefile.<platform> run-shared_file_main
 ```
 
-Refer to the top-level [README][../README.md] for usage details.
+Refer to the top-level [README](../../README.md) for usage details.

--- a/capability_sharing/mmap-shared-vs-private/build/Makefile.mmap_shared_vs_private
+++ b/capability_sharing/mmap-shared-vs-private/build/Makefile.mmap_shared_vs_private
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 The CapableVMs "CHERI Examples" Contributors.
+# Copyright (c) 2022 The CapableVMs "CHERI Examples" Contributors.
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
 # Common Makefile for the mmap_shared_vs_private example.

--- a/capability_sharing/read-cap-from-file/README.md
+++ b/capability_sharing/read-cap-from-file/README.md
@@ -7,4 +7,4 @@ built in a similar manner:
 $ make -f Makefile.<platform> run-read-cap-from-file
 ```
 
-Refer to the top-level [README][../README.md] for usage details.
+Refer to the top-level [README](../../README.md) for usage details.

--- a/capability_sharing/read-cap-from-file/build/Makefile.read-cap-from-file
+++ b/capability_sharing/read-cap-from-file/build/Makefile.read-cap-from-file
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 The CapableVMs "CHERI Examples" Contributors.
+# Copyright (c) 2022 The CapableVMs "CHERI Examples" Contributors.
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
 # Common Makefile for the read-cap-from-file examples.

--- a/capability_sharing/read-cap-from-pipe-with-sh/README.md
+++ b/capability_sharing/read-cap-from-pipe-with-sh/README.md
@@ -16,4 +16,4 @@ built in a similar manner:
 $ make -f Makefile.<platform> run-read-cap-from-pipe-with-sh
 ```
 
-Refer to the top-level [README][../README.md] for usage details.
+Refer to the top-level [README](../../README.md) for usage details.

--- a/capability_sharing/read-cap-from-pipe/README.md
+++ b/capability_sharing/read-cap-from-pipe/README.md
@@ -16,4 +16,4 @@ built in a similar manner:
 $ make -f Makefile.<platform> run-main
 ```
 
-Refer to the top-level [README][../README.md] for usage details.
+Refer to the top-level [README](../../README.md) for usage details.

--- a/employee/README.md
+++ b/employee/README.md
@@ -7,4 +7,4 @@ built in a similar manner:
 $ make -f Makefile.<platform>
 ```
 
-Refer to the top-level [README][../README.md] for usage details.
+Refer to the top-level [README](../README.md) for usage details.

--- a/shared_objects/README.md
+++ b/shared_objects/README.md
@@ -11,4 +11,4 @@ Unlike most other examples, these compile to a single executable (with
 accompanying shared objects). There is only a single `run-shared_objects`
 target, and the example is selected interactively.
 
-Otherwise, refer to the top-level [README][../README.md] for usage details.
+Otherwise, refer to the top-level [README](../README.md) for usage details.

--- a/syscall-restrict/README.md
+++ b/syscall-restrict/README.md
@@ -29,7 +29,7 @@ built in a similar manner:
 $ make -f Makefile.<platform>
 ```
 
-Refer to the top-level [README][../README.md] for usage details.
+Refer to the top-level [README](../README.md) for usage details.
 
 For example:
 

--- a/timsort/README.md
+++ b/timsort/README.md
@@ -7,7 +7,7 @@ built in a similar manner:
 $ make -f Makefile.<platform>
 ```
 
-Refer to the top-level [README][../README.md] for usage details.
+Refer to the top-level [README](../README.md) for usage details.
 
 For example:
 


### PR DESCRIPTION
This fixes the copyright year (which I got wrong for some of my examples), as well as some README typos.