### PR TITLE
Add the missing `base.h` file.

### DIFF
--- a/hybrid/compartment_examples/comp_setup/include/base.h
+++ b/hybrid/compartment_examples/comp_setup/include/base.h
@@ -1,0 +1,6 @@
+#define COMP_COUNT 1
+#define COMP_SIZE 80
+#define COMP_OFFSET_STK_ADDR 8
+#define COMP_OFFSET_STK_LEN 16
+#define COMP_OFFSET_DDC 48
+#define COMP_OFFSET_PCC 64

--- a/hybrid/compartment_examples/comp_setup/main.c
+++ b/hybrid/compartment_examples/comp_setup/main.c
@@ -64,7 +64,7 @@ struct comp
 };
 
 // ASM offsets, included here for validation
-#include "main.h"
+#include "include/base.h"
 
 static_assert(COMP_SIZE == sizeof(struct comp), "Invalid `COMP_SIZE` provided");
 static_assert(COMP_OFFSET_STK_ADDR == offsetof(struct comp, stack_addr),

--- a/hybrid/compartment_examples/comp_setup/shared.S
+++ b/hybrid/compartment_examples/comp_setup/shared.S
@@ -1,7 +1,7 @@
 // Copyright (c) 2021 The CapableVMs "CHERI Examples" Contributors.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-#include "main.h"
+#include "include/base.h"
 
 .global comp_f_fn
 


### PR DESCRIPTION
The `comp_setup` example doesn't build on `master`:
```
gabi@bencher14 ~/c/h/c/comp_setup > SSHPORT=10085 make -f ../Makefile.morello-hybrid run-main
/home/gabi/cheri/output/morello-sdk/bin/clang -E  shared.S > shared.s
shared.S:4:10: fatal error: 'main.h' file not found
         ^~~~~~~~
1 error generated.
make: *** [<builtin>: shared.s] Error 1
rm shared.s
```

It looks like `main.h` was accidentally removed at some point (#57). This patch reinstates it as `base.h` (for consistency with the other examples).