### PR TITLE
Replace unreachable `ret` instructions with `udf`.

### DIFF
--- a/hybrid/compartment_examples/inter_comp_call/malicious_compartments/secure-redirect_clr/shared.S
+++ b/hybrid/compartment_examples/inter_comp_call/malicious_compartments/secure-redirect_clr/shared.S
@@ -11,4 +11,5 @@ executive_switch:
     mov      x0, #0
     cvtp     clr, lr
     b        switch_compartment
-    ret      clr
+    // Unreachable (switch_compartment returns to main)
+    udf      #0xdead

--- a/hybrid/compartment_examples/inter_comp_call/malicious_compartments/secure-try_deref/shared.S
+++ b/hybrid/compartment_examples/inter_comp_call/malicious_compartments/secure-try_deref/shared.S
@@ -11,4 +11,5 @@ executive_switch:
     mov      x0, #0
     cvtp     clr, lr
     b        switch_compartment
-    ret      clr
+    // Unreachable (switch_compartment returns to main)
+    udf      #0xdead

--- a/hybrid/compartment_examples/inter_comp_call/malicious_compartments/secure-update_ddc/shared-update_ddc.S
+++ b/hybrid/compartment_examples/inter_comp_call/malicious_compartments/secure-update_ddc/shared-update_ddc.S
@@ -12,4 +12,5 @@ executive_switch:
     mov      x0, #0
     cvtp     clr, lr
     b        switch_compartment
-    ret      clr
+    // Unreachable (switch_compartment returns to main)
+    udf      #0xdead

--- a/hybrid/compartment_examples/inter_comp_call/malicious_compartments/secure/shared.S
+++ b/hybrid/compartment_examples/inter_comp_call/malicious_compartments/secure/shared.S
@@ -20,4 +20,5 @@ executive_switch:
     mov      x0, #0
     cvtp     clr, lr
     b        switch_compartment
-    ret      clr
+    // Unreachable (switch_compartment returns to main)
+    udf      #0xdead


### PR DESCRIPTION
This replaces several unreachable `ret` instructions with `udf` (the `permanently undefined` instruction). Using `udf` instead of `ret` makes it more obvious that `switch_compartment` doesn't return to `executive_switch` (it returns to the caller of `executive_switch`).