### PR TITLE
Fix CI not failing

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -50,7 +50,7 @@ args=(
 )
 export BUILDBOT_PLATFORM=riscv64-purecap
 args=${args[@]}
-script -O /dev/null -c "python3 tests/run_cheri_examples.py $args"
+script -O /dev/null -ec "python3 tests/run_cheri_examples.py $args"
 
 echo "Running tests for 'morello-hybrid' using QEMU..."
 args=(
@@ -66,7 +66,7 @@ args=(
 )
 export BUILDBOT_PLATFORM=morello-hybrid
 args=${args[@]}
-script -O /dev/null -c "python3 tests/run_cheri_examples.py $args"
+script -O /dev/null -ec "python3 tests/run_cheri_examples.py $args"
 
 echo "Running tests for 'morello-purecap' using QEMU..."
 args=(
@@ -82,4 +82,4 @@ args=(
 )
 export BUILDBOT_PLATFORM=morello-purecap
 args=${args[@]}
-script -O /dev/null -c "python3 tests/run_cheri_examples.py $args"
+script -O /dev/null -ec "python3 tests/run_cheri_examples.py $args"

--- a/hybrid/cap_build.c
+++ b/hybrid/cap_build.c
@@ -15,11 +15,12 @@
 //    from the first argument --- which differentiates `cheri_address_set` and
 //   `cheri_cap_build`.
 
-#include "cheriintrin.h"
-#include "include/common.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include "../include/common.h"
+#include "cheriintrin.h"
 
 int main()
 {

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -84,14 +84,14 @@ elif [ "$1" = "morello-hybrid" ]; then
     run to_fail hybrid/compartment_examples/inter_comp_call/malicious_compartments inter_comp_call-secure-redirect_clr
     run to_fail hybrid/compartment_examples/inter_comp_call/malicious_compartments inter_comp_call-secure-update_ddc
     # Tests that should pass
-    run OK . cap_build
     run OK compare_platforms compare_platforms_overflow
-    run OK hybrid/ddc_compartment_switching ddc_compartment_switching
+    run OK example_allocators/compartment_alloc main
     run OK hybrid basic_ddc
+    run OK hybrid cap_build
     run OK hybrid/compartment_examples/inter_comp_call/base main
     run OK hybrid/compartment_examples/inter_comp_call/malicious_compartments inter_comp_call-secure
+    run OK hybrid/ddc_compartment_switching ddc_compartment_switching
     run OK syscall-restrict syscall-restrict
-    run OK example_allocators/compartment_alloc main
 else
     echo "$1 not recognised."
     exit 1


### PR DESCRIPTION
Unfortunately, when we moved calling the underlying CHERI instance via `script` (in #93), we omitted to ensure that the return code for the underlying tests was properly returned to the testing script it's being called from. This means we had some underlying silent failures in our CI. We attempt to fix them here, and to ensure future CI checks fail appropriately.